### PR TITLE
Fix file explorer to show hidden directories

### DIFF
--- a/auto-claude-ui/src/main/ipc-handlers/file-handlers.ts
+++ b/auto-claude-ui/src/main/ipc-handlers/file-handlers.ts
@@ -8,8 +8,8 @@ import type { IPCResult, FileNode } from '../../shared/types';
 const IGNORED_DIRS = new Set([
   'node_modules', '.git', '__pycache__', 'dist', 'build',
   '.next', '.nuxt', 'coverage', '.cache', '.venv', 'venv',
-  '.idea', '.vscode', 'out', '.turbo', '.auto-claude',
-  '.worktrees', 'vendor', 'target', '.gradle', '.maven'
+  'out', '.turbo', '.worktrees',
+  'vendor', 'target', '.gradle', '.maven'
 ]);
 
 /**
@@ -29,8 +29,11 @@ export function registerFileHandlers(): void {
         // Filter and map entries
         const nodes: FileNode[] = [];
         for (const entry of entries) {
-          // Skip hidden files (except .env which is often useful)
-          if (entry.name.startsWith('.') && entry.name !== '.env') continue;
+          // Skip hidden files (not directories) except useful ones like .env, .gitignore
+          if (!entry.isDirectory() && entry.name.startsWith('.') &&
+              !['.env', '.gitignore', '.env.example', '.env.local'].includes(entry.name)) {
+            continue;
+          }
           // Skip ignored directories
           if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
 


### PR DESCRIPTION
## Problem
Users couldn't access hidden directories like `.claude`, `.auto-claude`, `.github`, `.vscode`, etc. when creating tasks or adding file references.

## Root Cause
File explorer filtered out ALL files/directories starting with `.` except `.env`, making important configuration directories invisible.

## Solution

### 1. Allow hidden directories to be visible
- Changed filter to only hide hidden FILES, not directories
- Hidden directories like `.claude`, `.github`, `.vscode`, `.idea` now visible
- Users can now reference files from these important configuration directories

### 2. Keep useful hidden files visible
- `.env`, `.gitignore`, `.env.example`, `.env.local` still shown
- Other random hidden files (`.DS_Store`, etc.) still filtered out

### 3. Updated IGNORED_DIRS
- Removed `.auto-claude` (contains user specs/data)
- Removed `.vscode` and `.idea` (users may need IDE config)
- Kept truly problematic dirs: `.git`, `node_modules`, `.cache`, `.worktrees`

## Testing
✅ Hidden directories now appear in Project Files browser
✅ Can drag and reference files from `.claude`, `.auto-claude`, `.github`, etc.
✅ Irrelevant hidden files still filtered out
✅ Build directories and node_modules still hidden

## Files Changed
- `auto-claude-ui/src/main/ipc-handlers/file-handlers.ts` - Updated file filtering logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and directory visibility by removing overly broad hidden-path filters
  * Enhanced handling of configuration and environment files in file listings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->