### PR TITLE
fix(changelog): detect Claude CLI at ~/.claude/local/claude

### DIFF
--- a/auto-claude-ui/src/main/changelog/changelog-service.ts
+++ b/auto-claude-ui/src/main/changelog/changelog-service.ts
@@ -70,6 +70,7 @@ export class ChangelogService extends EventEmitter {
         ]
       : [
           // Unix paths (macOS/Linux)
+          path.join(homeDir, '.claude/local/claude'),  // Claude Code default install location
           '/usr/local/bin/claude',
           '/opt/homebrew/bin/claude',
           path.join(homeDir, '.local/bin/claude'),


### PR DESCRIPTION
## Summary
- Fixed FileNotFoundError when generating changelogs by updating Claude CLI detection
- Added `~/.claude/local/claude` as the first search path (Claude Code's default install location)

## Problem
The changelog generator was failing with:
```
Python error: FileNotFoundError: [Errno 2] No such file or directory: 'claude'
```

This occurred because the `detectClaudePath()` method wasn't checking `~/.claude/local/claude`, which is where Claude Code installs by default on macOS/Linux.

## Solution
Updated the path detection order to check `~/.claude/local/claude` first in the Unix paths array.

## Test plan
- [x] Verified claude CLI location with `which claude` 
- [x] Test changelog generation in Electron UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Claude CLI detection on macOS and Linux by expanding the search paths checked when locating the CLI installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->