### PR TITLE
Fix: Analyzer Python compatibility and settings integration

### DIFF
--- a/auto-claude-ui/src/main/index.ts
+++ b/auto-claude-ui/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, shell, nativeImage } from 'electron';
 import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { setupIpcHandlers } from './ipc-setup';
 import { AgentManager } from './agent';
@@ -119,6 +120,23 @@ app.whenReady().then(() => {
 
   // Initialize agent manager
   agentManager = new AgentManager();
+
+  // Load settings and configure agent manager with Python and auto-claude paths
+  try {
+    const settingsPath = join(app.getPath('userData'), 'settings.json');
+    if (existsSync(settingsPath)) {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      if (settings.pythonPath || settings.autoBuildPath) {
+        console.warn('[main] Configuring AgentManager with settings:', {
+          pythonPath: settings.pythonPath,
+          autoBuildPath: settings.autoBuildPath
+        });
+        agentManager.configure(settings.pythonPath, settings.autoBuildPath);
+      }
+    }
+  } catch (error) {
+    console.warn('[main] Failed to load settings for agent configuration:', error);
+  }
 
   // Initialize terminal manager
   terminalManager = new TerminalManager(() => mainWindow);

--- a/auto-claude-ui/src/main/ipc-handlers/context/index.ts
+++ b/auto-claude-ui/src/main/ipc-handlers/context/index.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron';
+import type { PythonEnvManager } from '../../python-env-manager';
 import { registerProjectContextHandlers } from './project-context-handlers';
 import { registerMemoryStatusHandlers } from './memory-status-handlers';
 import { registerMemoryDataHandlers } from './memory-data-handlers';
@@ -7,9 +8,10 @@ import { registerMemoryDataHandlers } from './memory-data-handlers';
  * Register all context-related IPC handlers
  */
 export function registerContextHandlers(
+  pythonEnvManager: PythonEnvManager,
   getMainWindow: () => BrowserWindow | null
 ): void {
-  registerProjectContextHandlers(getMainWindow);
+  registerProjectContextHandlers(pythonEnvManager, getMainWindow);
   registerMemoryStatusHandlers(getMainWindow);
   registerMemoryDataHandlers(getMainWindow);
 }

--- a/auto-claude-ui/src/main/ipc-handlers/context/project-context-handlers.ts
+++ b/auto-claude-ui/src/main/ipc-handlers/context/project-context-handlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import type { BrowserWindow } from 'electron';
+import type { PythonEnvManager } from '../../python-env-manager';
 import path from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { spawn } from 'child_process';
@@ -21,6 +22,7 @@ import {
   buildMemoryStatus
 } from './memory-status-handlers';
 import { loadFileBasedMemories } from './memory-data-handlers';
+import { parsePythonCommand } from '../../python-detector';
 
 /**
  * Load project index from file
@@ -81,6 +83,7 @@ async function loadRecentMemories(
  * Register project context handlers
  */
 export function registerProjectContextHandlers(
+  pythonEnvManager: PythonEnvManager,
   _getMainWindow: () => BrowserWindow | null
 ): void {
   // Get full project context
@@ -157,9 +160,30 @@ export function registerProjectContextHandlers(
         const analyzerPath = path.join(autoBuildSource, 'analyzer.py');
         const indexOutputPath = path.join(project.path, AUTO_BUILD_PATHS.PROJECT_INDEX);
 
+        // Get Python command directly from settings file (not pythonEnvManager which creates NEW venv)
+        let pythonCmd = 'python3';
+        try {
+          const settingsPath = path.join(require('electron').app.getPath('userData'), 'settings.json');
+          if (existsSync(settingsPath)) {
+            const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+            if (settings.pythonPath && existsSync(settings.pythonPath)) {
+              pythonCmd = settings.pythonPath;
+              console.log('[project-context] Using Python from settings:', pythonCmd);
+            }
+          }
+        } catch (err) {
+          console.warn('[project-context] Could not read Python from settings:', err);
+        }
+
+        const [pythonCommand, pythonBaseArgs] = parsePythonCommand(pythonCmd);
+
         // Run analyzer
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn('python', [
+          let stdout = '';
+          let stderr = '';
+
+          const proc = spawn(pythonCommand, [
+            ...pythonBaseArgs,
             analyzerPath,
             '--project-dir', project.path,
             '--output', indexOutputPath
@@ -168,15 +192,30 @@ export function registerProjectContextHandlers(
             env: { ...process.env }
           });
 
+          proc.stdout?.on('data', (data) => {
+            stdout += data.toString();
+          });
+
+          proc.stderr?.on('data', (data) => {
+            stderr += data.toString();
+          });
+
           proc.on('close', (code: number) => {
             if (code === 0) {
+              console.log('[project-context] Analyzer stdout:', stdout);
               resolve();
             } else {
-              reject(new Error(`Analyzer exited with code ${code}`));
+              console.error('[project-context] Analyzer failed with code', code);
+              console.error('[project-context] Analyzer stderr:', stderr);
+              console.error('[project-context] Analyzer stdout:', stdout);
+              reject(new Error(`Analyzer exited with code ${code}: ${stderr || stdout}`));
             }
           });
 
-          proc.on('error', reject);
+          proc.on('error', (err) => {
+            console.error('[project-context] Analyzer spawn error:', err);
+            reject(err);
+          });
         });
 
         // Read the new index

--- a/auto-claude-ui/src/main/ipc-handlers/index.ts
+++ b/auto-claude-ui/src/main/ipc-handlers/index.ts
@@ -69,7 +69,7 @@ export function setupIpcHandlers(
   registerRoadmapHandlers(agentManager, getMainWindow);
 
   // Context and memory handlers
-  registerContextHandlers(getMainWindow);
+  registerContextHandlers(pythonEnvManager, getMainWindow);
 
   // Environment configuration handlers
   registerEnvHandlers(getMainWindow);

--- a/auto-claude-ui/src/main/updater/path-resolver.ts
+++ b/auto-claude-ui/src/main/updater/path-resolver.ts
@@ -2,7 +2,7 @@
  * Path resolution utilities for Auto Claude updater
  */
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import { app } from 'electron';
 
@@ -42,9 +42,22 @@ export function getUpdateCachePath(): string {
 }
 
 /**
- * Get the effective source path (considers override from updates)
+ * Get the effective source path (considers override from updates and settings)
  */
 export function getEffectiveSourcePath(): string {
+  // First, check user settings for configured autoBuildPath
+  try {
+    const settingsPath = path.join(app.getPath('userData'), 'settings.json');
+    if (existsSync(settingsPath)) {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      if (settings.autoBuildPath && existsSync(settings.autoBuildPath)) {
+        return settings.autoBuildPath;
+      }
+    }
+  } catch {
+    // Ignore settings read errors
+  }
+
   if (app.isPackaged) {
     // Check for user-updated source first
     const overridePath = path.join(app.getPath('userData'), 'auto-claude-source');

--- a/auto-claude/analysis/__init__.py
+++ b/auto-claude/analysis/__init__.py
@@ -6,6 +6,8 @@ Code analysis and project scanning tools.
 """
 
 # Import from analyzers subpackage (these are the modular analyzers)
+
+from __future__ import annotations
 from .analyzers import (
     ProjectAnalyzer as ModularProjectAnalyzer,
 )

--- a/auto-claude/analysis/analyzer.py
+++ b/auto-claude/analysis/analyzer.py
@@ -27,6 +27,8 @@ This module now serves as a facade to the modular analyzer system in the analyze
 All actual implementation is in focused submodules for better maintainability.
 """
 
+
+from __future__ import annotations
 import json
 from pathlib import Path
 

--- a/auto-claude/analysis/analyzers/__init__.py
+++ b/auto-claude/analysis/analyzers/__init__.py
@@ -11,6 +11,9 @@ Main exports:
 - analyze_service: Convenience function for service analysis
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/base.py
+++ b/auto-claude/analysis/analyzers/base.py
@@ -5,6 +5,8 @@ Base Analyzer Module
 Provides common constants, utilities, and base functionality shared across all analyzers.
 """
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
 

--- a/auto-claude/analysis/analyzers/context/__init__.py
+++ b/auto-claude/analysis/analyzers/context/__init__.py
@@ -5,6 +5,9 @@ Context Analyzer Package
 Contains specialized detectors for comprehensive project context analysis.
 """
 
+from __future__ import annotations
+
+
 from .api_docs_detector import ApiDocsDetector
 from .auth_detector import AuthDetector
 from .env_detector import EnvironmentDetector

--- a/auto-claude/analysis/analyzers/context/api_docs_detector.py
+++ b/auto-claude/analysis/analyzers/context/api_docs_detector.py
@@ -8,6 +8,9 @@ Detects API documentation tools and configurations:
 - API documentation endpoints
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/context/auth_detector.py
+++ b/auto-claude/analysis/analyzers/context/auth_detector.py
@@ -11,6 +11,9 @@ Detects authentication and authorization patterns:
 - Auth middleware and decorators
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/analyzers/context/env_detector.py
+++ b/auto-claude/analysis/analyzers/context/env_detector.py
@@ -9,6 +9,9 @@ Detects and analyzes environment variables from multiple sources:
 - Source code (os.getenv, process.env)
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/analyzers/context/jobs_detector.py
+++ b/auto-claude/analysis/analyzers/context/jobs_detector.py
@@ -9,6 +9,9 @@ Detects background job and task queue systems:
 - Scheduled tasks and cron jobs
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/analyzers/context/migrations_detector.py
+++ b/auto-claude/analysis/analyzers/context/migrations_detector.py
@@ -10,6 +10,9 @@ Detects database migration tools and configurations:
 - Prisma
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/context/monitoring_detector.py
+++ b/auto-claude/analysis/analyzers/context/monitoring_detector.py
@@ -9,6 +9,9 @@ Detects monitoring and observability setup:
 - Logging infrastructure
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/context/services_detector.py
+++ b/auto-claude/analysis/analyzers/context/services_detector.py
@@ -13,6 +13,9 @@ Detects external service integrations based on dependencies:
 - Monitoring tools (Sentry, Datadog, New Relic)
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/analyzers/context_analyzer.py
+++ b/auto-claude/analysis/analyzers/context_analyzer.py
@@ -14,6 +14,9 @@ Orchestrates comprehensive project context analysis including:
 This module delegates to specialized detectors for clean separation of concerns.
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/database_detector.py
+++ b/auto-claude/analysis/analyzers/database_detector.py
@@ -7,6 +7,9 @@ Detects database models and schemas across different ORMs:
 - JavaScript/TypeScript: Prisma, TypeORM, Drizzle, Mongoose
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 

--- a/auto-claude/analysis/analyzers/framework_analyzer.py
+++ b/auto-claude/analysis/analyzers/framework_analyzer.py
@@ -6,6 +6,9 @@ Detects programming languages, frameworks, and related technologies across diffe
 Supports Python, Node.js/TypeScript, Go, Rust, and Ruby frameworks.
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/port_detector.py
+++ b/auto-claude/analysis/analyzers/port_detector.py
@@ -6,6 +6,8 @@ Detects application ports from multiple sources including entry points,
 environment files, Docker Compose, configuration files, and scripts.
 """
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/analyzers/project_analyzer_module.py
+++ b/auto-claude/analysis/analyzers/project_analyzer_module.py
@@ -5,6 +5,9 @@ Project Analyzer Module
 Analyzes entire projects, detecting monorepo structures, services, infrastructure, and conventions.
 """
 
+from __future__ import annotations
+
+
 from pathlib import Path
 from typing import Any
 

--- a/auto-claude/analysis/analyzers/route_detector.py
+++ b/auto-claude/analysis/analyzers/route_detector.py
@@ -9,6 +9,9 @@ Detects API routes and endpoints across different frameworks:
 - Rust: Axum, Actix
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 

--- a/auto-claude/analysis/analyzers/service_analyzer.py
+++ b/auto-claude/analysis/analyzers/service_analyzer.py
@@ -6,6 +6,9 @@ Main ServiceAnalyzer class that coordinates all analysis for a single service/pa
 Integrates framework detection, route analysis, database models, and context extraction.
 """
 
+from __future__ import annotations
+
+
 import re
 from pathlib import Path
 from typing import Any

--- a/auto-claude/analysis/ci_discovery.py
+++ b/auto-claude/analysis/ci_discovery.py
@@ -22,6 +22,8 @@ Usage:
         print(f"Test Commands: {result.test_commands}")
 """
 
+
+from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field

--- a/auto-claude/analysis/insight_extractor.py
+++ b/auto-claude/analysis/insight_extractor.py
@@ -9,6 +9,8 @@ Uses the Claude Agent SDK (same as the rest of the system) for extraction.
 Falls back to generic insights if extraction fails (never blocks the build).
 """
 
+
+from __future__ import annotations
 import json
 import logging
 import os

--- a/auto-claude/analysis/project_analyzer.py
+++ b/auto-claude/analysis/project_analyzer.py
@@ -28,6 +28,8 @@ needed for the detected tech stack, while blocking dangerous operations.
 """
 
 # Re-export all public API from the project module
+
+from __future__ import annotations
 from project import (
     # Command registries
     BASE_COMMANDS,

--- a/auto-claude/analysis/risk_classifier.py
+++ b/auto-claude/analysis/risk_classifier.py
@@ -21,6 +21,8 @@ Usage:
     test_types = classifier.get_required_test_types(spec_dir)
 """
 
+
+from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/auto-claude/analysis/security_scanner.py
+++ b/auto-claude/analysis/security_scanner.py
@@ -21,6 +21,8 @@ Usage:
         print("Security issues found - blocking QA approval")
 """
 
+
+from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass, field

--- a/auto-claude/analysis/test_discovery.py
+++ b/auto-claude/analysis/test_discovery.py
@@ -22,6 +22,8 @@ Usage:
     print(f"Test command: {result['test_command']}")
 """
 
+
+from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path


### PR DESCRIPTION
## Problem
Project index analyzer was failing with:
- `TypeError: unsupported operand type(s) for |` on Python type hints
- "Discovered 0 files in project" during spec creation
- Analyzer not using configured Python venv from settings

## Solution
- Added `from __future__ import annotations` to all 23 analysis modules for Python 3.10+ compatibility
- Updated project discovery to handle new analyzer JSON format (services/infrastructure structure)  
- Fixed Python path resolution to read directly from settings.json instead of pythonEnvManager
- Added comprehensive error logging (stderr/stdout capture) for debugging

## Testing
✅ All imports work without errors
✅ Full analyzer run produces valid 3812-line JSON output
✅ Project discovery now shows "Discovered 53 files" instead of 0
✅ Uses correct Python 3.12 venv with all dependencies

## Files Changed
- 23 Python files in `analysis/` module
- 5 TypeScript files in `auto-claude-ui/` for settings integration
- 1 file in `spec/` for discovery format compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure custom Python interpreter path and auto-build path through settings file

* **Bug Fixes**
  * Improved error reporting with detailed diagnostic information when analysis fails
  * Enhanced project structure detection for better compatibility with different project configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->