### PR TITLE
fix: use python detector for project analyzer

### DIFF
--- a/auto-claude-ui/src/main/ipc-handlers/context/project-context-handlers.ts
+++ b/auto-claude-ui/src/main/ipc-handlers/context/project-context-handlers.ts
@@ -21,6 +21,7 @@ import {
   buildMemoryStatus
 } from './memory-status-handlers';
 import { loadFileBasedMemories } from './memory-data-handlers';
+import { parsePythonCommand, findPythonCommand } from '../../python-detector';
 
 /**
  * Load project index from file
@@ -159,7 +160,15 @@ export function registerProjectContextHandlers(
 
         // Run analyzer
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn('python', [
+          const pythonCmd = findPythonCommand();
+          if (!pythonCmd) {
+            reject(new Error('Python 3 not found. Please install Python 3 or ensure it is in your PATH.'));
+            return;
+          }
+
+          const [command, baseArgs] = parsePythonCommand(pythonCmd);
+          const proc = spawn(command, [
+            ...baseArgs,
             analyzerPath,
             '--project-dir', project.path,
             '--output', indexOutputPath


### PR DESCRIPTION
## Summary
Replace hardcoded 'python' command with `findPythonCommand()` utility that properly detects python3 on macOS/Unix systems.

## Problem
Clicking "Analyze project" in the Context section fails with:
```
Failed to load project index
spawn python ENOENT
```

This occurs on macOS/Unix systems where `python` is not in PATH (only `python3` exists).

## Solution
- Use existing `python-detector.ts` utility to detect correct Python command
- Try `python3` first on Unix systems, `python` on Windows
- Provide clear error message if Python 3 not found
- Handle multi-part commands like "py -3" on Windows

## Testing
- ✅ ESLint passed (no new errors/warnings)
- ✅ TypeScript type checking passed
- ✅ Tested on macOS - "Analyze project" now works correctly

## Changes
- Modified: `auto-claude-ui/src/main/ipc-handlers/context/project-context-handlers.ts`
  - Import `findPythonCommand` and `parsePythonCommand` from `python-detector`
  - Replace hardcoded `spawn('python', ...)` with detected Python command
  - Add error handling for when Python 3 is not found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Python environment compatibility through improved interpreter detection and command resolution. The application now reliably identifies and invokes Python across diverse system configurations, including environments with multiple installed versions, custom installation paths, and non-standard setups. Project context operations now function consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->