### PR TITLE
fix: remove legacy path from auto-claude source detection

### DIFF
--- a/apps/frontend/src/main/agent/agent-process.ts
+++ b/apps/frontend/src/main/agent/agent-process.ts
@@ -63,9 +63,7 @@ export class AgentProcessManager {
       // Alternative: from app root -> apps/backend
       path.resolve(app.getAppPath(), '..', 'backend'),
       // If running from repo root with apps structure
-      path.resolve(process.cwd(), 'apps', 'backend'),
-      // Legacy: auto-claude folder (for backwards compatibility)
-      path.resolve(process.cwd(), 'auto-claude')
+      path.resolve(process.cwd(), 'apps', 'backend')
     ];
 
     for (const p of possiblePaths) {


### PR DESCRIPTION
## Problem

Auto-Claude UI was displaying error:
```
[ERROR] Spec runner not found at: /Users/jorisslagter/Developer/Tools/auto-claude/auto-claude/runners/spec_runner.py
```

The spec_runner.py actually exists at the correct location in the new monorepo structure:
```
/Users/jorisslagter/Developer/Tools/auto-claude/apps/backend/runners/spec_runner.py
```

## Root Cause

The `detectAutoBuildSourcePath()` function in `agent-process.ts` was checking multiple possible paths and selecting the first one that had `requirements.txt`. The issue was that the **legacy** `auto-claude/` path (from before the monorepo restructure in v2.7.2) was being selected instead of the new `apps/backend/` path.

```typescript
const possiblePaths = [
  path.resolve(__dirname, '..', '..', '..', 'backend'),
  path.resolve(app.getAppPath(), '..', 'backend'),
  path.resolve(process.cwd(), 'apps', 'backend'),
  path.resolve(process.cwd(), 'auto-claude')  // ← This was being selected!
];
```

## Solution

Removed the legacy path from the array completely. Since the project has fully migrated to the new monorepo structure, backwards compatibility with the old structure is not needed.

**Change in `apps/frontend/src/main/agent/agent-process.ts`:**
- Removed line 68: `path.resolve(process.cwd(), 'auto-claude')`
- Removed associated comment

## Impact

After this fix:
- ✅ Path detection correctly identifies: `/path/to/apps/backend/`
- ✅ Spec runner is found at: `/path/to/apps/backend/runners/spec_runner.py`
- ✅ No more "[ERROR] Spec runner not found" messages
- ✅ Forces migration to new monorepo structure
- ✅ Cleaner code - removes dead legacy path

## Testing

Tested in development mode:
1. Started Auto-Claude UI with `npm run dev`
2. Verified path detection logs show correct backend path
3. Created new spec/task - spec runner is found correctly
4. No errors about missing spec_runner.py

## Fixes

Closes #147

## Related

Part of monorepo restructure alignment (v2.7.2, #138)