### PR TITLE
fix: terminal button error handling and worktree path display

### DIFF
--- a/auto-claude-ui/src/renderer/components/task-detail/hooks/useTerminalHandler.ts
+++ b/auto-claude-ui/src/renderer/components/task-detail/hooks/useTerminalHandler.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+/**
+ * Hook for handling terminal creation with proper error handling and loading states.
+ * Fixes silent failures when terminal buttons are clicked.
+ */
+export function useTerminalHandler() {
+  const [error, setError] = useState<string | null>(null);
+  const [isOpening, setIsOpening] = useState(false);
+
+  const openTerminal = async (id: string, cwd: string) => {
+    setIsOpening(true);
+    setError(null);
+
+    try {
+      const result = await window.electronAPI.createTerminal({ id, cwd });
+
+      if (!result.success) {
+        setError(result.error || 'Failed to open terminal');
+        console.error('[Terminal] Failed to open:', result.error);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+      setError(`Failed to open terminal: ${errorMsg}`);
+      console.error('[Terminal] Exception:', err);
+    } finally {
+      setIsOpening(false);
+    }
+  };
+
+  return { openTerminal, error, isOpening };
+}

--- a/auto-claude-ui/src/renderer/components/task-detail/task-review/StagedSuccessMessage.tsx
+++ b/auto-claude-ui/src/renderer/components/task-detail/task-review/StagedSuccessMessage.tsx
@@ -3,6 +3,7 @@ import { GitMerge, ExternalLink, Copy, Check, Sparkles } from 'lucide-react';
 import { Button } from '../../ui/button';
 import { Textarea } from '../../ui/textarea';
 import type { Task } from '../../../../shared/types';
+import { useTerminalHandler } from '../hooks/useTerminalHandler';
 
 interface StagedSuccessMessageProps {
   stagedSuccess: string;
@@ -22,6 +23,7 @@ export function StagedSuccessMessage({
 }: StagedSuccessMessageProps) {
   const [commitMessage, setCommitMessage] = useState(suggestedCommitMessage || '');
   const [copied, setCopied] = useState(false);
+  const { openTerminal, error: terminalError, isOpening } = useTerminalHandler();
 
   const handleCopy = async () => {
     if (!commitMessage) return;
@@ -93,20 +95,23 @@ export function StagedSuccessMessage({
         </ol>
       </div>
       {stagedProjectPath && (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            window.electronAPI.createTerminal({
-              id: `project-${task.id}`,
-              cwd: stagedProjectPath
-            });
-          }}
-          className="w-full"
-        >
-          <ExternalLink className="mr-2 h-4 w-4" />
-          Open Project in Terminal
-        </Button>
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openTerminal(`project-${task.id}`, stagedProjectPath)}
+            className="w-full"
+            disabled={isOpening}
+          >
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {isOpening ? 'Opening Terminal...' : 'Open Project in Terminal'}
+          </Button>
+          {terminalError && (
+            <div className="mt-2 text-sm text-red-600">
+              {terminalError}
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description
Fixes terminal buttons failing silently on macOS and adds worktree path visibility.

## Related Issues
Fixes #109, partially fixes #117

## Root Causes

### Issue #109: "Open Project in Terminal" Button Doesn't Work
- Button calls `createTerminal()` without awaiting Promise
- No error handling at UI level
- Silent failures - button does nothing when clicked

### Issue #117 (partial): Cannot View Worktree Location
- Worktree path available in data but not displayed
- No way to see where files are located
- Same terminal button issue affects review workflow

## Changes Made

### 1. Create Reusable Terminal Handler Hook
- New `useTerminalHandler.ts` hook
- Properly awaits `createTerminal()` Promise
- Tracks loading state (`isOpening`)
- Captures and displays errors
- Logs detailed error info to console

### 2. Update All Terminal Buttons (3 locations)
**StagedSuccessMessage.tsx:**
- "Open Project in Terminal" button
- Uses hook with error handling
- Shows loading state
- Displays error messages

**WorkspaceStatus.tsx (2 buttons):**
- "Open in Worktree Terminal" button
- "Open in Main Project Terminal" button
- Both use hook with error handling
- Both show loading states

### 3. Add Worktree Path Display
- Shows worktree path in WorkspaceStatus component
- Users can now see exact location: `.worktrees/{spec-id}/`
- Helpful for manual testing and debugging

### 4. Improve Error Reporting
- Terminal spawn errors now visible to user
- Errors logged to console with full details
- Clear messaging when terminal fails

## Testing

### Manual Testing Performed
- [x] Clicked "Open Project in Terminal" - works
- [x] Clicked "Open Worktree Terminal" - works
- [x] Clicked "Open Main Project Terminal" - works
- [x] Simulated error - message displayed to user
- [x] Loading state shows while opening
- [x] Worktree path visible in UI

### Code Coverage
- useTerminalHandler.ts: Error handling hook
- StagedSuccessMessage.tsx: Terminal button
- WorkspaceStatus.tsx: Two terminal buttons + path display

## Before/After

**Before:**
- Click terminal button → nothing happens
- No error messages
- No loading feedback
- Silent failures on macOS
- Can't see worktree location

**After:**
- Click terminal button → shows "Opening..."
- Terminal opens in correct directory
- Clear error if terminal fails
- Detailed console logs
- Worktree path visible

## Breaking Changes
None - fully backward compatible

## UI/UX Improvements
- Loading states provide feedback
- Error messages guide users
- Worktree path helps debugging
- Consistent behavior across all terminal buttons

## Related PRs
- This is part 3 of 4 PRs to fix issues #87, #89, #109, #117, #132, #133

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>