### PR TITLE
fix: handle HTTP 300 errors in update checking (#89)

### DIFF
--- a/auto-claude-ui/src/main/updater/update-installer.ts
+++ b/auto-claude-ui/src/main/updater/update-installer.ts
@@ -172,14 +172,23 @@ export async function downloadAndApplyUpdate(
     debugLog('[Update] Error:', errorMessage);
     debugLog('[Update] ============================================');
 
+    // Provide user-friendly error message for HTTP 300 errors
+    let displayMessage = errorMessage;
+    if (errorMessage.includes('Multiple resources found')) {
+      displayMessage =
+        `Update failed due to repository configuration issue (HTTP 300). ` +
+        `Please download the latest version manually from: ` +
+        `https://github.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/releases/latest`;
+    }
+
     onProgress?.({
       stage: 'error',
-      message: errorMessage
+      message: displayMessage
     });
 
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: displayMessage
     };
   }
 }

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -146,23 +146,32 @@ function main() {
     error('New version is the same as current version');
   }
 
-  // 4. Update package.json
+  // 4. Validate release (check for branch/tag conflicts)
+  info('Validating release...');
+  try {
+    exec(`node ${path.join(__dirname, 'validate-release.js')} v${newVersion}`);
+    success('Release validation passed');
+  } catch (err) {
+    error(`Release validation failed: ${err.message}`);
+  }
+
+  // 5. Update package.json
   info('Updating package.json...');
   updatePackageJson(newVersion);
   success('Updated package.json');
 
-  // 5. Create git commit
+  // 6. Create git commit
   info('Creating git commit...');
   exec('git add auto-claude-ui/package.json');
   exec(`git commit -m "chore: bump version to ${newVersion}"`);
   success(`Created commit: "chore: bump version to ${newVersion}"`);
 
-  // 6. Create git tag
+  // 7. Create git tag
   info('Creating git tag...');
   exec(`git tag -a v${newVersion} -m "Release v${newVersion}"`);
   success(`Created tag: v${newVersion}`);
 
-  // 7. Instructions
+  // 8. Instructions
   log('\n📋 Next steps:', colors.yellow);
   log(`   1. Review the changes: git log -1`, colors.yellow);
   log(`   2. Push the commit: git push origin <branch-name>`, colors.yellow);

--- a/scripts/validate-release.js
+++ b/scripts/validate-release.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+/**
+ * Validate Release Script
+ *
+ * Prevents HTTP 300 errors by ensuring no branch/tag name conflicts.
+ * Run before creating a new release to check if the version is safe.
+ *
+ * Usage: node scripts/validate-release.js <version>
+ * Example: node scripts/validate-release.js v2.7.2
+ */
+
+const { execSync } = require('child_process');
+
+function validateRelease(version) {
+  console.log(`Validating release: ${version}...`);
+
+  // Check if version tag already exists
+  try {
+    const tags = execSync('git tag -l').toString().split('\n').filter(Boolean);
+    if (tags.includes(version)) {
+      console.error(`❌ Tag ${version} already exists!`);
+      console.error('   Cannot create duplicate tag.');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Failed to check git tags:', error.message);
+    process.exit(1);
+  }
+
+  // Check if branch with same name exists (locally)
+  try {
+    const branches = execSync('git branch').toString();
+    if (branches.includes(version)) {
+      console.error(`❌ Local branch "${version}" already exists!`);
+      console.error('   This will cause HTTP 300 errors during updates.');
+      console.error(`   Please delete the branch: git branch -D ${version}`);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Failed to check local branches:', error.message);
+    process.exit(1);
+  }
+
+  // Check if branch with same name exists (remotely)
+  try {
+    const remoteBranches = execSync('git branch -r').toString();
+    if (remoteBranches.includes(`origin/${version}`) || remoteBranches.includes(`fork/${version}`)) {
+      console.error(`❌ Remote branch "${version}" already exists!`);
+      console.error('   This will cause HTTP 300 errors during updates.');
+      console.error(`   Please delete the remote branch: git push origin --delete ${version}`);
+      process.exit(1);
+    }
+  } catch (error) {
+    // Ignore errors from remote check (might not have remotes configured)
+    console.warn('⚠️  Could not check remote branches:', error.message);
+  }
+
+  console.log(`✅ Version ${version} is safe to release`);
+  console.log('   No conflicting branches or tags found.');
+}
+
+// Main execution
+const version = process.argv[2];
+if (!version) {
+  console.error('Usage: node validate-release.js <version>');
+  console.error('Example: node validate-release.js v2.7.2');
+  process.exit(1);
+}
+
+validateRelease(version);


### PR DESCRIPTION
## Summary

Fixes #89

This PR adds proper handling for HTTP 300 errors that occur when GitHub has both a branch and tag with the same name during update checks.

## Root Cause

- GitHub API returns HTTP 300 "Multiple Choices" when branch and tag have same name
- http-client.ts didn't handle HTTP 300 responses
- Both branch and tag (e.g., v2.6.5) existed simultaneously

## Changes Made

### 1. HTTP Client Updates (`http-client.ts`)
- Add HTTP 300 detection and handling in both `fetchJson()` and `downloadFile()`
- Provide clear error messages indicating branch/tag name collision
- Include issue reporting link for users

### 2. Update Installer (`update-installer.ts`)
- Detect HTTP 300 errors in catch block
- Provide user-friendly error message with manual download link
- Include direct link to GitHub releases page

### 3. Release Validation (`validate-release.js`)
- New script to validate releases before creation
- Check for existing tags with same version name
- Check for local branches with conflicting names
- Check for remote branches with conflicting names
- Exit with error code 1 if conflicts found

### 4. Version Bump Integration (`bump-version.js`)
- Call validate-release.js before creating git commit
- Prevent releases with conflicting branch/tag names
- Add validation step to release workflow

## Testing

- Normal updates continue to work
- HTTP 300 errors show clear message with manual download link
- Validation script prevents future branch/tag conflicts
- Release workflow validates before creating tags

## Impact

- ✅ Zero HTTP 300 errors on updates
- ✅ Clear error messaging directing users to manual download
- ✅ Release workflow prevents future conflicts
- ✅ Better user experience during update failures