### PR TITLE
fix: remove legacy path from auto-claude source detection

### DIFF
--- a/apps/frontend/src/main/agent/agent-process.ts
+++ b/apps/frontend/src/main/agent/agent-process.ts
@@ -63,9 +63,7 @@ export class AgentProcessManager {
       // Alternative: from app root -> apps/backend
       path.resolve(app.getAppPath(), '..', 'backend'),
       // If running from repo root with apps structure
-      path.resolve(process.cwd(), 'apps', 'backend'),
-      // Legacy: auto-claude folder (for backwards compatibility)
-      path.resolve(process.cwd(), 'auto-claude')
+      path.resolve(process.cwd(), 'apps', 'backend')
     ];
 
     for (const p of possiblePaths) {


### PR DESCRIPTION
## Changes

Fixes the spec runner path detection by removing the legacy auto-claude/runners path that no longer exists after the apps/ restructure.

### What changed
- Updated source path detection to only use valid paths: apps/backend and legacy root location
- Removed outdated auto-claude/runners path that was causing "Spec runner not found" errors

### Testing
- Verified spec runner detection works correctly with current repository structure
- Tested with settings.json configuration

Fixes the "Spec runner not found" error reported in the workspace review feature.