### PR TITLE
fix: Add Python 3.10+ version validation and GitHub Actions Python setup (#180 #167)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -84,6 +89,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -147,6 +157,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -187,6 +202,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

This PR fixes critical bug #180 and #167 where macOS users with default Python 3.9.6 couldn't use Auto-Claude because `claude-agent-sdk` requires Python 3.10+.

## Root Cause Analysis

The investigation revealed that Auto-Claude:
- **Does NOT bundle Python** - relies entirely on system Python
- Had **no version validation** - accepted any Python 3.x
- **macOS default**: Ships with Python 3.9.6 (incompatible with claude-agent-sdk >=0.1.16)
- **GitHub Actions**: Build workflows didn't explicitly set Python version

This caused the following error chain:
```
System has Python 3.9.6
→ PythonEnvManager creates venv with 3.9.6
→ Tries to install claude-agent-sdk>=0.1.16
→ Fails: "No matching distribution found" (requires Python 3.10+)
→ depsInstalled = false, ready = false
→ Tasks can't run, workspaces can't be created
→ ModuleNotFoundError: dotenv (can't install any dependencies)
```

## Changes

### 1. `apps/frontend/src/main/python-detector.ts`

Added version validation functions:
- `getPythonVersion()` - Extracts version from `python --version` output
- `validatePythonVersion()` - Checks if Python >= 3.10.0
- Updated `findPythonCommand()` to validate versions and skip Python < 3.10 with clear error messages

**Before**: Accepted any Python 3.x
```typescript
if (version.includes('Python 3')) {
  return cmd;
}
```

**After**: Validates minimum version requirement
```typescript
const validation = validatePythonVersion(cmd);
if (validation.valid) {
  console.log(`[Python] Found valid Python: ${cmd} (${validation.version})`);
  return cmd;
} else {
  console.warn(`[Python] ${cmd} version too old: ${validation.message}`);
  continue;
}
```

### 2. `apps/frontend/src/main/python-env-manager.ts`

- Imported and used `findPythonCommand()` (which now has built-in version validation)
- Simplified `findSystemPython()` to use shared validation logic (removed 50+ lines of duplicate code)
- Updated error message from "Python 3.9+" to "Python 3.10+" with download link

**Before**:
```typescript
this.emit('error', 'Python 3 not found. Please install Python 3.9+');
```

**After**:
```typescript
this.emit(
  'error',
  'Python 3.10+ not found. Please install Python 3.10 or higher (required by claude-agent-sdk).\n\n' +
  'Download: https://www.python.org/downloads/'
);
```

### 3. `.github/workflows/release.yml`

Added Python 3.11 setup to **all 4 build jobs**:
- `build-macos-intel`
- `build-macos-arm64`
- `build-windows`
- `build-linux`

```yaml
- name: Setup Python
  uses: actions/setup-python@v5
  with:
    python-version: '3.11'
```

This ensures consistent Python version across all platforms during CI/CD builds.

## Impact

✅ **macOS users with Python 3.9**: Now see clear error message with download link
✅ **macOS users with Python 3.10+**: Work normally  
✅ **CI/CD builds**: Use consistent Python 3.11 across all platforms
✅ **Error prevention**: Stops "ModuleNotFoundError: dotenv" and dependency install failures at the source

## Testing

- [x] Code review - all changes match implementation plan
- [x] TypeScript syntax validated
- [x] Version comparison logic tested (3.9 < 3.10, 3.10 >= 3.10, 3.11 >= 3.10)
- [x] Error messages include clear download link
- [x] All 4 GitHub Actions jobs updated consistently

## Files Changed

- `.github/workflows/release.yml` - Added Python 3.11 setup to all build jobs
- `apps/frontend/src/main/python-detector.ts` - Added version validation functions
- `apps/frontend/src/main/python-env-manager.ts` - Use validated Python, improved error message

## Closes

Fixes #180  
Fixes #167

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated minimum Python version requirement to 3.10+ for better platform compatibility
* Enhanced Python environment detection with improved version validation
* Streamlined CI/CD pipeline setup for multiple build platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->