### PR TITLE
fix: add future annotations import to discovery.py

### DIFF
--- a/apps/backend/spec/discovery.py
+++ b/apps/backend/spec/discovery.py
@@ -5,6 +5,8 @@ Discovery Module
 Project structure analysis and indexing.
 """
 
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess


### PR DESCRIPTION
## Summary
Adds `from __future__ import annotations` to `apps/backend/spec/discovery.py` for Python 3.9+ compatibility with type hints.

## Background
This completes the Python compatibility fixes from #128. While 25/26 analysis files already had the future annotations import (applied in develop), `spec/discovery.py` was still missing it.

## Changes
- Added `from __future__ import annotations` to `apps/backend/spec/discovery.py`

## Testing
- [x] Verified all 26 Python files in `apps/backend/analysis/` and `apps/backend/spec/` now have the import
- [x] No functional changes, only future-proofing for Python 3.9+ type hint compatibility

## Related
- Completes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python module configuration in the backend service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->