### PR TITLE
fix: update path resolution for ollama_model_detector.py in memory

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/memory-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/memory-handlers.ts
@@ -112,7 +112,7 @@ async function executeOllamaDetector(
   // Find the ollama_model_detector.py script
   const possiblePaths = [
     // Development paths
-    path.resolve(__dirname, '..', '..', '..', '..', 'backend', 'ollama_model_detector.py'),
+    path.resolve(__dirname, '..', '..', '..', 'backend', 'ollama_model_detector.py'),
     path.resolve(process.cwd(), 'apps', 'backend', 'ollama_model_detector.py'),
     // Legacy paths (for backwards compatibility)
     path.resolve(__dirname, '..', '..', '..', 'auto-claude', 'ollama_model_detector.py'),
@@ -540,7 +540,7 @@ export function registerMemoryHandlers(): void {
         // Find the ollama_model_detector.py script
         const possiblePaths = [
           // New apps structure
-          path.resolve(__dirname, '..', '..', '..', '..', 'backend', 'ollama_model_detector.py'),
+          path.resolve(__dirname, '..', '..', '..', 'backend', 'ollama_model_detector.py'),
           path.resolve(process.cwd(), 'apps', 'backend', 'ollama_model_detector.py'),
           // Legacy paths for backwards compatibility
           path.resolve(__dirname, '..', '..', '..', 'auto-claude', 'ollama_model_detector.py'),


### PR DESCRIPTION
This pull request updates the path resolution logic for locating the `ollama_model_detector.py` script in the `memory-handlers.ts` file. The main change is removing an extra directory level from the relative path, ensuring the script can be reliably found in the updated project structure.

Path resolution update:

* Updated the relative path in both `executeOllamaDetector` and `registerMemoryHandlers` to remove one level of directory traversal when searching for `ollama_model_detector.py`. This aligns the lookup with the current project structure and prevents path resolution errors. [[1]](diffhunk://#diff-019950d851a363d5a84f07b7988310b19269f5e9c64d37c3514ec63c8ec25b91L115-R115) [[2]](diffhunk://#diff-019950d851a363d5a84f07b7988310b19269f5e9c64d37c3514ec63c8ec25b91L543-R543)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script discovery logic for model detection, ensuring the correct script is located across different project configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->