### PR TITLE
fix(ci): use correct electron-builder arch flags

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -112,7 +112,7 @@ jobs:
         run: cd apps/frontend && npm run build
 
       - name: Package macOS (Intel)
-        run: cd apps/frontend && npm run package:mac -- --arch=x64
+        run: cd apps/frontend && npm run package:mac -- --x64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
@@ -180,7 +180,7 @@ jobs:
         run: cd apps/frontend && npm run build
 
       - name: Package macOS (Apple Silicon)
-        run: cd apps/frontend && npm run package:mac -- --arch=arm64
+        run: cd apps/frontend && npm run package:mac -- --arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: cd apps/frontend && npm run build
 
       - name: Package macOS (Intel)
-        run: cd apps/frontend && npm run package:mac -- --arch=x64
+        run: cd apps/frontend && npm run package:mac -- --x64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
@@ -116,7 +116,7 @@ jobs:
         run: cd apps/frontend && npm run build
 
       - name: Package macOS (Apple Silicon)
-        run: cd apps/frontend && npm run package:mac -- --arch=arm64
+        run: cd apps/frontend && npm run package:mac -- --arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}


### PR DESCRIPTION
## Summary
- Fixes Mac Intel and ARM64 builds failing with "Unknown argument: arch"
- Changes deprecated `--arch=x64` to `--x64` and `--arch=arm64` to `--arm64` in both workflow files

## Root Cause
When the project switched from pnpm to npm, the argument passing behavior changed:
- **pnpm**: `pnpm run script -- --arg` adds a `--` separator, so electron-builder ignores `--arch`
- **npm**: `npm run script -- --arg` passes it directly, causing electron-builder to reject the deprecated `--arch` flag

## Changes
| File | Line | Before | After |
|------|------|--------|-------|
| `beta-release.yml` | 115 | `--arch=x64` | `--x64` |
| `beta-release.yml` | 183 | `--arch=arm64` | `--arm64` |
| `release.yml` | 50 | `--arch=x64` | `--x64` |
| `release.yml` | 119 | `--arch=arm64` | `--arm64` |

## Test plan
- [ ] Trigger beta-release workflow with dry_run=true to verify Mac builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS release workflow to use optimized architecture flags for Intel and Apple Silicon packaging, ensuring more streamlined and reliable builds for both platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->