### PR TITLE
fix(build): add --force-local flag to tar on Windows

### DIFF
--- a/apps/frontend/scripts/download-python.cjs
+++ b/apps/frontend/scripts/download-python.cjs
@@ -255,8 +255,16 @@ function extractTarGz(archivePath, destDir) {
   // Ensure destination exists
   fs.mkdirSync(destDir, { recursive: true });
 
+  // Build tar arguments
+  // On Windows, paths like D:\path are misinterpreted as remote host:path
+  // --force-local tells tar to treat colons as part of the filename
+  const tarArgs = ['-xzf', archivePath, '-C', destDir];
+  if (os.platform() === 'win32') {
+    tarArgs.unshift('--force-local');
+  }
+
   // Use tar command with array arguments (safer than string interpolation)
-  const result = spawnSync('tar', ['-xzf', archivePath, '-C', destDir], {
+  const result = spawnSync('tar', tarArgs, {
     stdio: 'inherit',
   });
 


### PR DESCRIPTION
## Summary
- Fixes Windows build failure in beta-release workflow
- On Windows, paths like `D:\path` are misinterpreted by tar as remote host syntax (`host:path`)
- Adding `--force-local` tells tar to treat colons as part of the filename

## Error Fixed
```
tar (child): Cannot connect to D: resolve failed
gzip: stdin: unexpected end of file
tar: Child returned status 128
tar: Error is not recoverable: exiting now
```

## Test plan
- [ ] Re-run beta-release workflow after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)