### PR TITLE
fix(github): add augmented PATH env to all gh CLI calls

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/github/oauth-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/oauth-handlers.ts
@@ -242,7 +242,8 @@ export function registerStartGhAuth(): void {
           debugLog('Spawning: gh', args);
 
           const ghProcess = spawn('gh', args, {
-            stdio: ['pipe', 'pipe', 'pipe']
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env: getAugmentedEnv()
           });
 
           let output = '';
@@ -399,7 +400,8 @@ export function registerGetGhToken(): void {
         debugLog('Running: gh auth token');
         const token = execSync('gh auth token', {
           encoding: 'utf-8',
-          stdio: 'pipe'
+          stdio: 'pipe',
+          env: getAugmentedEnv()
         }).trim();
 
         if (!token) {
@@ -438,7 +440,8 @@ export function registerGetGhUser(): void {
         debugLog('Running: gh api user');
         const userJson = execSync('gh api user', {
           encoding: 'utf-8',
-          stdio: 'pipe'
+          stdio: 'pipe',
+          env: getAugmentedEnv()
         });
 
         debugLog('User API response received');
@@ -479,7 +482,8 @@ export function registerListUserRepos(): void {
           'gh repo list --limit 100 --json nameWithOwner,description,isPrivate',
           {
             encoding: 'utf-8',
-            stdio: 'pipe'
+            stdio: 'pipe',
+            env: getAugmentedEnv()
           }
         );
 
@@ -585,7 +589,8 @@ export function registerGetGitHubBranches(): void {
           ['api', apiEndpoint, '--paginate', '--jq', '.[].name'],
           {
             encoding: 'utf-8',
-            stdio: 'pipe'
+            stdio: 'pipe',
+            env: getAugmentedEnv()
           }
         );
 
@@ -632,7 +637,8 @@ export function registerCreateGitHubRepo(): void {
         // Get the authenticated username
         const username = execSync('gh api user --jq .login', {
           encoding: 'utf-8',
-          stdio: 'pipe'
+          stdio: 'pipe',
+          env: getAugmentedEnv()
         }).trim();
 
         // Determine the owner (personal account or organization)
@@ -662,7 +668,8 @@ export function registerCreateGitHubRepo(): void {
         const output = execFileSync('gh', args, {
           encoding: 'utf-8',
           cwd: options.projectPath,
-          stdio: 'pipe'
+          stdio: 'pipe',
+          env: getAugmentedEnv()
         });
 
         debugLog('gh repo create output:', output);
@@ -768,7 +775,8 @@ export function registerListGitHubOrgs(): void {
         // Get user's organizations
         const output = execSync('gh api user/orgs --jq \'.[] | {login: .login, avatarUrl: .avatar_url}\'', {
           encoding: 'utf-8',
-          stdio: 'pipe'
+          stdio: 'pipe',
+          env: getAugmentedEnv()
         });
 
         // Parse the JSON lines output

--- a/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import { IPC_CHANNELS, MODEL_ID_MAP, DEFAULT_FEATURE_MODELS, DEFAULT_FEATURE_THINKING } from '../../../shared/constants';
 import { getGitHubConfig, githubFetch } from './utils';
 import { readSettingsFile } from '../../settings-utils';
+import { getAugmentedEnv } from '../../env-utils';
 import type { Project, AppSettings } from '../../../shared/types';
 import { createContextLogger } from './utils/logger';
 import { withProjectOrNull } from './utils/project-middleware';
@@ -477,6 +478,7 @@ export function registerPRHandlers(
           const diff = execFileSync('gh', ['pr', 'diff', String(prNumber)], {
             cwd: project.path,
             encoding: 'utf-8',
+            env: getAugmentedEnv(),
           });
           return diff;
         } catch {
@@ -748,6 +750,7 @@ export function registerPRHandlers(
             // Use execFileSync with arguments array to prevent command injection
             execFileSync('gh', ['pr', 'comment', String(prNumber), '--body-file', tmpFile], {
               cwd: project.path,
+              env: getAugmentedEnv(),
             });
             unlinkSync(tmpFile);
           } catch (error) {
@@ -848,6 +851,7 @@ export function registerPRHandlers(
           // Use execFileSync with arguments array to prevent command injection
           execFileSync('gh', ['pr', 'merge', String(prNumber), `--${mergeMethod}`], {
             cwd: project.path,
+            env: getAugmentedEnv(),
           });
           debugLog('PR merged successfully', { prNumber });
           return true;

--- a/apps/frontend/src/main/ipc-handlers/github/triage-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/triage-handlers.ts
@@ -14,6 +14,7 @@ import fs from 'fs';
 import { IPC_CHANNELS, MODEL_ID_MAP, DEFAULT_FEATURE_MODELS, DEFAULT_FEATURE_THINKING } from '../../../shared/constants';
 import { getGitHubConfig } from './utils';
 import { readSettingsFile } from '../../settings-utils';
+import { getAugmentedEnv } from '../../env-utils';
 import type { Project, AppSettings } from '../../../shared/types';
 import { createContextLogger } from './utils/logger';
 import { withProjectOrNull } from './utils/project-middleware';
@@ -435,6 +436,7 @@ export function registerTriageHandlers(
                 // Use execFileSync with arguments array to prevent command injection
                 execFileSync('gh', ['issue', 'edit', String(issueNumber), '--add-label', safeLabels.join(',')], {
                   cwd: project.path,
+                  env: getAugmentedEnv(),
                 });
               }
             }


### PR DESCRIPTION
## Summary
- Fixes "gh: command not found" error when connecting projects to GitHub in the packaged macOS app (.dmg)
- The issue occurs because packaged apps don't inherit the user's shell PATH, so gh installed via Homebrew at `/opt/homebrew/bin` isn't found

## Changes
Added `env: getAugmentedEnv()` to all gh CLI calls in:
- `oauth-handlers.ts` - spawn(), execSync(), execFileSync() calls
- `pr-handlers.ts` - execFileSync() calls for pr diff, comment, merge
- `triage-handlers.ts` - execFileSync() call for issue label editing

The `getAugmentedEnv()` function adds common binary paths like `/opt/homebrew/bin` and `/usr/local/bin` to the PATH.

## Error Fixed
```
Command failed: gh auth token /bin/sh: gh: command not found
spawn gh ENOENT
```

## Test plan
- [ ] Build macOS .dmg package
- [ ] Install and launch from Applications
- [ ] Connect a project to GitHub - should work without "command not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)