### PR TITLE
fix(project): solve task status reverting to 'Start' on refresh (#246)

### DIFF
--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -548,7 +548,7 @@ export class ProjectStore {
       if (storedStatus) {
         // Planning/coding status from the backend should be respected even if subtasks aren't in progress yet
         // This happens when a task is in planning phase (creating spec) but no subtasks have been started
-        const isActiveProcessStatus = (plan.status as string) === 'planning' || (plan.status as string) === 'coding';
+        const isActiveProcessStatus = (plan.status as string) === 'planning' || (plan.status as string) === 'coding' || (plan.status as string) === 'in_progress';
 
         // Check if this is a plan review (spec approval stage before coding starts)
         // planStatus: "review" indicates spec creation is complete and awaiting user approval


### PR DESCRIPTION
## Description

Fixes Issue #246 where task status would revert from 'in_progress' to 'backlog' (Start button) after a page refresh.

**Root Cause:**
The `determineTaskStatusAndReason` function recalculates status based on subtasks. If no subtasks are started yet (e.g. early planning), it calculates 'backlog'. The validation logic was strictly rejecting the persisted 'in_progress' status because it didn't match 'backlog'.

**Fix:**
Relaxed validation to explicitly allow 'in_progress' persistence when the underlying plan status is also 'in_progress'.

## Testing
- Verified with reproduction test case (failed before, passed after)
- Verified active regression tests pass

Fixes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan status evaluation to properly recognize projects in an "in progress" state as active plans, improving accuracy of process status tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->