### PR TITLE
fix(ci): remove version bump to fix branch protection conflict

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -33,7 +33,7 @@ jobs:
           echo "Valid beta version: $VERSION"
 
   create-tag:
-    name: Update version and create beta tag
+    name: Create beta tag
     needs: validate-version
     runs-on: ubuntu-latest
     permissions:
@@ -44,72 +44,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Update version in all files
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          echo "Updating version to $VERSION in all files..."
-
-          # Update apps/frontend/package.json
-          cd apps/frontend
-          npm pkg set version="$VERSION"
-          echo "✅ Updated apps/frontend/package.json to $VERSION"
-          cd ../..
-
-          # Update root package.json
-          npm pkg set version="$VERSION"
-          echo "✅ Updated root package.json to $VERSION"
-
-          # Update apps/backend/__init__.py
-          if [ -f "apps/backend/__init__.py" ]; then
-            sed -i "s/__version__ = \".*\"/__version__ = \"$VERSION\"/" apps/backend/__init__.py
-            echo "✅ Updated apps/backend/__init__.py to $VERSION"
-          fi
-
-          # Verify the updates
-          echo ""
-          echo "Verification:"
-          echo "  Frontend: $(grep '"version"' apps/frontend/package.json | head -1)"
-          echo "  Root: $(grep '"version"' package.json | head -1)"
-          if [ -f "apps/backend/__init__.py" ]; then
-            echo "  Backend: $(grep '__version__' apps/backend/__init__.py)"
-          fi
-
-      - name: Commit version update and create tag
+      - name: Create and push tag
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           VERSION="${{ github.event.inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Commit version changes
-          git add apps/frontend/package.json package.json
-          if [ -f "apps/backend/__init__.py" ]; then
-            git add apps/backend/__init__.py
-          fi
-          git commit -m "chore: bump version to $VERSION for beta release"
-
-          # Create annotated tag
           git tag -a "v$VERSION" -m "Beta release v$VERSION"
-
-          # Push both commit and tag
-          git push origin develop
           git push origin "v$VERSION"
-          echo "✅ Committed version update and created tag v$VERSION"
+          echo "Created tag v$VERSION"
 
       - name: Create tag only (dry run)
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          echo "DRY RUN: Would commit version update and create tag v$VERSION"
-          echo "Files that would be updated:"
-          git status --short
+          echo "DRY RUN: Would create tag v$VERSION"
 
   # Intel build on Intel runner for native compilation
   build-macos-intel:


### PR DESCRIPTION
Removes the automatic version bump code that was trying to push commits to the protected develop branch.

The workflow will now just create the tag without modifying package.json files. Version bumps should be done manually before running the release workflow.

This fixes the release failure caused by branch protection rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined beta release workflow for improved efficiency. The release process now focuses on tag creation and deployment, removing unnecessary version update steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->