### PR TITLE
refactor(components): remove deprecated TaskDetailPanel re-export

### DIFF
--- a/apps/frontend/src/renderer/components/TaskDetailPanel.tsx
+++ b/apps/frontend/src/renderer/components/TaskDetailPanel.tsx
@@ -1,3 +1,0 @@
-// Backwards compatibility re-export
-// This file has been refactored into smaller components in ./task-detail/
-export { TaskDetailPanel } from './task-detail';

--- a/apps/frontend/src/renderer/components/index.ts
+++ b/apps/frontend/src/renderer/components/index.ts
@@ -2,7 +2,6 @@
 export * from './Sidebar';
 export * from './KanbanBoard';
 export * from './TaskCard';
-export * from './TaskDetailPanel';
 export * from './TaskCreationWizard';
 export * from './TaskEditDialog';
 export * from './AppSettings';


### PR DESCRIPTION
  ## Base Branch

  - [x] This PR targets the `develop` branch (required for all feature/fix PRs)
  - [ ] This PR targets `main` (hotfix only - maintainers)

  ## Description

  Remove the unused `TaskDetailPanel.tsx` backwards compatibility re-export file. The app imports directly from `./task-detail/TaskDetailModal`, making this re-export file dead code.

  ## Related Issue

  N/A - Code cleanup

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 📚 Documentation
  - [x] ♻️ Refactor
  - [ ] 🧪 Test

  ## Area

  - [x] Frontend
  - [ ] Backend
  - [ ] Fullstack

  ## Checklist

  - [x] I've synced with `develop` branch
  - [x] I've tested my changes locally
  - [x] I've followed the code principles (SOLID, DRY, KISS)
  - [x] My PR is small and focused (< 400 lines ideally)

  ## CI/Testing Requirements

  - [x] All CI checks pass
  - [x] All existing tests pass
  - [ ] New features include test coverage
  - [ ] Bug fixes include regression tests

  ## Feature Toggle

  - [x] N/A - Feature is complete and ready for all users

  ## Breaking Changes

  **Breaking:** No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed TaskDetailPanel from public component exports. Consumers must now import TaskDetailPanel directly from its source location rather than through the barrel exports. This is a breaking change for existing imports using the public re-export path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->