### PR TITLE
fix(ui): close parent modal when Edit dialog opens

### DIFF
--- a/apps/frontend/src/renderer/components/task-detail/TaskDetailModal.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskDetailModal.tsx
@@ -307,7 +307,11 @@ function TaskDetailModalContent({ open, task, onOpenChange, onSwitchToTerminals,
                     variant="ghost"
                     size="icon"
                     className="hover:bg-primary/10 hover:text-primary transition-colors"
-                    onClick={() => state.setIsEditDialogOpen(true)}
+                    onClick={() => {
+                      state.setIsEditDialogOpen(true);
+                      // Hide parent modal while edit dialog is open to fix z-index stacking
+                      onOpenChange(false);
+                    }}
                     disabled={state.isRunning && !state.isStuck}
                   >
                     <Pencil className="h-4 w-4" />
@@ -469,7 +473,13 @@ function TaskDetailModalContent({ open, task, onOpenChange, onSwitchToTerminals,
       <TaskEditDialog
         task={task}
         open={state.isEditDialogOpen}
-        onOpenChange={state.setIsEditDialogOpen}
+        onOpenChange={(open) => {
+          state.setIsEditDialogOpen(open);
+          // Reopen parent modal when edit dialog closes
+          if (!open) {
+            onOpenChange(true);
+          }
+        }}
       />
 
       {/* Delete Confirmation Dialog */}


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch

## Description

Fixes #235

The Edit Task modal's close button (X) was unresponsive because both the parent modal and the edit dialog used `z-50` for their overlays. The parent's overlay was intercepting clicks meant for the edit dialog's close button.

### Root Cause

When TaskEditDialog opens from within TaskDetailModal:
- Parent modal overlay: `z-50`
- Parent modal content: `z-50`
- Edit dialog overlay: `z-50`
- Edit dialog content: `z-50`

All at the same z-index, causing the parent's overlay to intercept clicks on the edit dialog.

### Solution

Hide the parent modal while the Edit dialog is open, then reopen it when the Edit dialog closes. This provides a cleaner UX than z-index stacking hacks.

## Testing

- [x] TypeScript compiles without errors
- [x] No breaking changes

## Checklist

- [x] PR targets `develop` branch
- [x] Commit is signed off (DCO)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal stacking issues when opening the edit dialog during task editing
  * Improved task editing workflow to automatically return to the task detail view after making changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->