### PR TITLE
docs: fix README download links to point to v2.7.2-beta.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Auto Claude Kanban Board](.github/assets/Auto-Claude-Kanban.png)
 
-[![Version](https://img.shields.io/badge/version-2.7.2--beta.10-blue?style=flat-square)](https://github.com/AndyMik90/Auto-Claude/releases/latest)
+[![Version](https://img.shields.io/badge/version-2.7.2--beta.10-blue?style=flat-square)](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green?style=flat-square)](./agpl-3.0.txt)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/KCXaPBr4Dj)
 [![CI](https://img.shields.io/github/actions/workflow/status/AndyMik90/Auto-Claude/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/AndyMik90/Auto-Claude/actions)
@@ -17,11 +17,11 @@ Get the latest pre-built release for your platform:
 
 | Platform | Download | Notes |
 |----------|----------|-------|
-| **Windows** | [Auto-Claude-2.7.2-beta.10.exe](https://github.com/AndyMik90/Auto-Claude/releases/latest) | Installer (NSIS) |
-| **macOS (Apple Silicon)** | [Auto-Claude-2.7.2-beta.10-arm64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/latest) | M1/M2/M3 Macs |
-| **macOS (Intel)** | [Auto-Claude-2.7.2-beta.10-x64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/latest) | Intel Macs |
-| **Linux** | [Auto-Claude-2.7.2-beta.10.AppImage](https://github.com/AndyMik90/Auto-Claude/releases/latest) | Universal |
-| **Linux (Debian)** | [Auto-Claude-2.7.2-beta.10.deb](https://github.com/AndyMik90/Auto-Claude/releases/latest) | Ubuntu/Debian |
+| **Windows** | [Auto-Claude-2.7.2-beta.10.exe](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10) | Installer (NSIS) |
+| **macOS (Apple Silicon)** | [Auto-Claude-2.7.2-beta.10-arm64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10) | M1/M2/M3 Macs |
+| **macOS (Intel)** | [Auto-Claude-2.7.2-beta.10-x64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10) | Intel Macs |
+| **Linux** | [Auto-Claude-2.7.2-beta.10.AppImage](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10) | Universal |
+| **Linux (Debian)** | [Auto-Claude-2.7.2-beta.10.deb](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10) | Ubuntu/Debian |
 
 > All releases include SHA256 checksums and VirusTotal scan results for security verification.
 


### PR DESCRIPTION
## Summary
Fixes #374

The `/releases/latest` URL redirects to the last stable release (v2.7.1), not the current beta (v2.7.2-beta.10). This caused users clicking download links in the README to get the wrong version.

## Changes
- Updated version badge link
- Updated all 5 platform download links

All links now point directly to `/releases/tag/v2.7.2-beta.10`.

## Note
When 2.7.2 is marked as a stable release, these links can be reverted to `/releases/latest` for automatic updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated download and release links to point to a specific release version (v2.7.2-beta.10) instead of the generic latest release across all platforms (Windows, macOS, and Linux).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->