### PR TITLE
feat(analyzer): add iOS/Swift project detection

### DIFF
--- a/apps/frontend/src/renderer/components/context/ServiceCard.tsx
+++ b/apps/frontend/src/renderer/components/context/ServiceCard.tsx
@@ -106,6 +106,34 @@ export function ServiceCard({ name, service }: ServiceCardProps) {
           )}
         </div>
 
+        {/* Apple Frameworks (iOS/Swift) */}
+        {service.apple_frameworks && service.apple_frameworks.length > 0 && (
+          <div className="pt-2 border-t border-border">
+            <p className="text-xs text-muted-foreground mb-1.5">Apple Frameworks</p>
+            <div className="flex flex-wrap gap-1">
+              {service.apple_frameworks.map((fw) => (
+                <Badge key={fw} variant="secondary" className="text-xs">
+                  {fw}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* SPM Dependencies (iOS/Swift) */}
+        {service.spm_dependencies && service.spm_dependencies.length > 0 && (
+          <div className="pt-2 border-t border-border">
+            <p className="text-xs text-muted-foreground mb-1.5">SPM Dependencies</p>
+            <div className="flex flex-wrap gap-1">
+              {service.spm_dependencies.map((dep) => (
+                <Badge key={dep} variant="outline" className="text-xs font-mono">
+                  {dep}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Collapsible Sections */}
         <EnvironmentSection environment={service.environment} />
         <APIRoutesSection api={service.api} />

--- a/apps/frontend/src/renderer/components/context/constants.ts
+++ b/apps/frontend/src/renderer/components/context/constants.ts
@@ -8,7 +8,9 @@ import {
   FileCode,
   Lightbulb,
   FolderTree,
-  AlertTriangle
+  AlertTriangle,
+  Smartphone,
+  Monitor
 } from 'lucide-react';
 
 // Service type icon mapping
@@ -19,6 +21,8 @@ export const serviceTypeIcons: Record<string, React.ElementType> = {
   scraper: Code,
   library: Package,
   proxy: GitBranch,
+  mobile: Smartphone,
+  desktop: Monitor,
   unknown: FileCode
 };
 
@@ -30,6 +34,8 @@ export const serviceTypeColors: Record<string, string> = {
   scraper: 'bg-green-500/10 text-green-400 border-green-500/30',
   library: 'bg-gray-500/10 text-gray-400 border-gray-500/30',
   proxy: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/30',
+  mobile: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
+  desktop: 'bg-indigo-500/10 text-indigo-400 border-indigo-500/30',
   unknown: 'bg-muted text-muted-foreground border-muted'
 };
 

--- a/apps/frontend/src/shared/types/project.ts
+++ b/apps/frontend/src/shared/types/project.ts
@@ -50,7 +50,7 @@ export interface ServiceInfo {
   path: string;
   language?: string;
   framework?: string;
-  type?: 'backend' | 'frontend' | 'worker' | 'scraper' | 'library' | 'proxy' | 'unknown';
+  type?: 'backend' | 'frontend' | 'worker' | 'scraper' | 'library' | 'proxy' | 'mobile' | 'desktop' | 'unknown';
   package_manager?: string;
   default_port?: number;
   entry_point?: string;
@@ -65,6 +65,9 @@ export interface ServiceInfo {
   styling?: string;
   state_management?: string;
   build_tool?: string;
+  // iOS/Swift specific
+  apple_frameworks?: string[];
+  spm_dependencies?: string[];
   dockerfile?: string;
   consumes?: string[];
   environment?: {


### PR DESCRIPTION
## Summary
Adds iOS/Swift project detection to Auto-Claude's framework analyzer.

## Changes
- Detect Swift projects via Package.swift or .xcodeproj
- Identify SwiftUI, UIKit, AppKit frameworks
- Detect Apple frameworks (Combine, MapKit, WidgetKit, etc.)
- Parse SPM dependencies from xcodeproj or Package.swift
- Add mobile/desktop project types with icons

## Testing
- ✅ Swift project detection works
- ✅ TypeScript detection still works (no regression)
- ✅ Linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Swift/iOS project analysis that detects Apple frameworks and Swift Package Manager dependencies.
  * Extended service types to include mobile and desktop, with corresponding icons and colors.
  * UI now shows detected Apple frameworks and SPM dependencies as visual badges in project/service details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->