### PR TITLE
fix(analyzer): move Swift detection before Ruby detection

### DIFF
--- a/apps/backend/analysis/analyzers/framework_analyzer.py
+++ b/apps/backend/analysis/analyzers/framework_analyzer.py
@@ -75,14 +75,7 @@ class FrameworkAnalyzer(BaseAnalyzer):
             content = self._read_file("Cargo.toml")
             self._detect_rust_framework(content)
 
-        # Ruby detection
-        elif self._exists("Gemfile"):
-            self.analysis["language"] = "Ruby"
-            self.analysis["package_manager"] = "bundler"
-            content = self._read_file("Gemfile")
-            self._detect_ruby_framework(content)
-
-        # Swift/iOS detection
+        # Swift/iOS detection (check BEFORE Ruby - iOS projects often have Gemfile for CocoaPods/Fastlane)
         elif self._exists("Package.swift") or any(self.path.glob("*.xcodeproj")):
             self.analysis["language"] = "Swift"
             if self._exists("Package.swift"):
@@ -90,6 +83,13 @@ class FrameworkAnalyzer(BaseAnalyzer):
             else:
                 self.analysis["package_manager"] = "Xcode"
             self._detect_swift_framework()
+
+        # Ruby detection
+        elif self._exists("Gemfile"):
+            self.analysis["language"] = "Ruby"
+            self.analysis["package_manager"] = "bundler"
+            content = self._read_file("Gemfile")
+            self._detect_ruby_framework(content)
 
     def _detect_python_framework(self, content: str) -> None:
         """Detect Python framework."""


### PR DESCRIPTION
## Summary
Fixes iOS/Swift projects being incorrectly detected as Ruby.

## Problem
iOS projects often have a `Gemfile` for CocoaPods/Fastlane dependencies. The detection order in `framework_analyzer.py` checked Ruby first, causing iOS projects to be incorrectly identified as Ruby instead of Swift.

## Solution
Move Swift/iOS detection **before** Ruby detection in the `elif` chain. This ensures `.xcodeproj` and `Package.swift` are checked first, correctly identifying iOS projects even when a `Gemfile` is present.

## Before
```
project-name → Ruby / bundler
```

## After
```
project-name → Swift / SwiftUI / Xcode
Apple Frameworks: Combine, MapKit, WidgetKit, CoreLocation, etc.
SPM Dependencies: supabase-swift, purchases-ios, posthog-ios
```

Follow-up fix for #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved framework detection priority to prevent conflicts between Swift and Ruby detection in projects with mixed frameworks.

* **Documentation**
  * Enhanced comments clarifying framework detection ordering logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->