### PR TITLE
fix(github): pass repo parameter to GHClient for explicit PR resolution

### DIFF
--- a/apps/backend/runners/github/context_gatherer.py
+++ b/apps/backend/runners/github/context_gatherer.py
@@ -201,13 +201,15 @@ class PRContext:
 class PRContextGatherer:
     """Gathers all context needed for PR review BEFORE the AI starts."""
 
-    def __init__(self, project_dir: Path, pr_number: int):
+    def __init__(self, project_dir: Path, pr_number: int, repo: str | None = None):
         self.project_dir = Path(project_dir)
         self.pr_number = pr_number
+        self.repo = repo
         self.gh_client = GHClient(
             project_dir=self.project_dir,
             default_timeout=30.0,
             max_retries=3,
+            repo=repo,
         )
 
     async def gather(self) -> PRContext:
@@ -953,14 +955,17 @@ class FollowupContextGatherer:
         project_dir: Path,
         pr_number: int,
         previous_review: PRReviewResult,  # Forward reference
+        repo: str | None = None,
     ):
         self.project_dir = Path(project_dir)
         self.pr_number = pr_number
         self.previous_review = previous_review
+        self.repo = repo
         self.gh_client = GHClient(
             project_dir=self.project_dir,
             default_timeout=30.0,
             max_retries=3,
+            repo=repo,
         )
 
     async def gather(self) -> FollowupReviewContext:

--- a/apps/backend/runners/github/orchestrator.py
+++ b/apps/backend/runners/github/orchestrator.py
@@ -129,6 +129,7 @@ class GitHubOrchestrator:
             default_timeout=30.0,
             max_retries=3,
             enable_rate_limiting=True,
+            repo=config.repo,
         )
 
         # Initialize bot detector for preventing infinite loops
@@ -300,7 +301,9 @@ class GitHubOrchestrator:
         try:
             # Gather PR context
             print("[DEBUG orchestrator] Creating context gatherer...", flush=True)
-            gatherer = PRContextGatherer(self.project_dir, pr_number)
+            gatherer = PRContextGatherer(
+                self.project_dir, pr_number, repo=self.config.repo
+            )
 
             print("[DEBUG orchestrator] Gathering PR context...", flush=True)
             pr_context = await gatherer.gather()

--- a/apps/backend/runners/github/providers/github_provider.py
+++ b/apps/backend/runners/github/providers/github_provider.py
@@ -56,6 +56,7 @@ class GitHubProvider:
             self._gh_client = GHClient(
                 project_dir=project_dir,
                 enable_rate_limiting=self.enable_rate_limiting,
+                repo=self._repo,
             )
 
     @property


### PR DESCRIPTION
## Summary
- Add `repo` parameter to `GHClient` constructor to explicitly specify the target repository
- Add `-R owner/repo` flag to all PR-related `gh` CLI commands (`pr_list`, `pr_get`, `pr_diff`, `pr_review`, `pr_merge`, `pr_comment`)
- Pass `repo` through the call chain: `orchestrator` → `PRContextGatherer` → `GHClient`

## Problem
The `gh` CLI was failing with `"Could not resolve to a PullRequest with the number of 262"` because it inferred the repository from git remotes instead of using an explicit repository. With multiple remotes configured (forks, upstream, etc.), the wrong repo could be queried.

## Solution
Pass the `repo` parameter through the entire call chain and add the `-R owner/repo` flag to all PR-related gh commands, ensuring the correct repository is always queried regardless of git remote configuration.

## Test plan
- [x] All 1141 tests pass
- [x] Python syntax validation passes
- [x] Manual verification of `GHClient` repo flag behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved GitHub integration backend to support optional repository specification across components, enhancing system flexibility and reliability in repository-scoped operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->