### PR TITLE
fix(model): respect task_metadata.json model selection

### DIFF
--- a/apps/backend/agents/planner.py
+++ b/apps/backend/agents/planner.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 
 from core.client import create_client
-from phase_config import get_phase_thinking_budget
+from phase_config import get_phase_model, get_phase_thinking_budget
 from phase_event import ExecutionPhase, emit_phase
 from task_logger import (
     LogPhase,
@@ -91,12 +91,14 @@ async def run_followup_planner(
         task_logger.start_phase(LogPhase.PLANNING, "Starting follow-up planning...")
         task_logger.set_session(1)
 
-    # Create client (fresh context) with planning phase thinking budget
+    # Create client with phase-specific model and thinking budget
+    # Respects task_metadata.json configuration when no CLI override
+    planning_model = get_phase_model(spec_dir, "planning", model)
     planning_thinking_budget = get_phase_thinking_budget(spec_dir, "planning")
     client = create_client(
         project_dir,
         spec_dir,
-        model,
+        planning_model,
         max_thinking_tokens=planning_thinking_budget,
     )
 

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -276,8 +276,9 @@ def main() -> None:
     project_dir = get_project_dir(args.project_dir)
     debug("run.py", f"Using project directory: {project_dir}")
 
-    # Get model (with env var fallback)
-    model = args.model or os.environ.get("AUTO_BUILD_MODEL", DEFAULT_MODEL)
+    # Get model from CLI arg or env var (None if not explicitly set)
+    # This allows get_phase_model() to fall back to task_metadata.json
+    model = args.model or os.environ.get("AUTO_BUILD_MODEL")
 
     # Handle --list command
     if args.list:

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -255,6 +255,7 @@ export interface AppSettings {
   betaUpdates?: boolean;
   // Migration flags (internal use)
   _migratedAgentProfileToAuto?: boolean;
+  _migratedDefaultModelSync?: boolean;
   // Language preference for UI (i18n)
   language?: SupportedLanguage;
   // Developer tools preferences


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes model selection being ignored - user selects "Balanced" profile (Sonnet) in UI but actual API calls use Opus. The `task_metadata.json` has `"model": "sonnet"` but was being bypassed because `cli/main.py` always defaulted to Opus when no CLI arg was provided, causing `get_phase_model()` to skip reading task metadata.

## Related Issue

Closes #414

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [ ] Backend
- [x] Fullstack

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## CI/Testing Requirements

- [x] All CI checks pass
- [x] All existing tests pass
- [ ] New features include test coverage
- [x] Bug fixes include regression tests

## Feature Toggle

- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

## Implementation Details

### Backend Fixes
- **cli/main.py:280** - Removed `DEFAULT_MODEL` fallback so `model` is `None` when not explicitly set via CLI arg or `AUTO_BUILD_MODEL` env var. This allows `get_phase_model()` to correctly read from `task_metadata.json`.
- **agents/planner.py:94-103** - Added `get_phase_model()` call to resolve model from task metadata, matching the pattern used by coder.py and qa/loop.py.

### Frontend Fixes
- **settings-handlers.ts:151-159** - Syncs `defaultModel` with `selectedAgentProfile` when user changes agent profile, fixing the stuck "opus" value.
- **settings-handlers.ts:114-125** - Migration for existing users to sync their `defaultModel` with their current `selectedAgentProfile`.
- **settings.ts:258** - Added `_migratedDefaultModelSync` type for the new migration flag.

### Root Cause
The model resolution priority was:
1. CLI `--model` arg
2. `AUTO_BUILD_MODEL` env var
3. `DEFAULT_MODEL` (hardcoded opus) ← **This was the bug**

When #3 was used, `get_phase_model()` treated it as an explicit override and never checked `task_metadata.json`. Now #3 returns `None`, allowing proper fallback to task metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model configuration inconsistencies during settings initialization and updates.

* **Chores**
  * Improved automatic synchronization of model settings with selected agent profiles.
  * Enhanced phase-specific model configuration for better consistency across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->