### PR TITLE
fix(spec_runner): add --base-branch argument support

### DIFF
--- a/apps/backend/runners/spec_runner.py
+++ b/apps/backend/runners/spec_runner.py
@@ -192,6 +192,12 @@ Examples:
         action="store_true",
         help="Skip human review checkpoint and automatically approve spec for building",
     )
+    parser.add_argument(
+        "--base-branch",
+        type=str,
+        default=None,
+        help="Base branch for creating worktrees (default: auto-detect or current branch)",
+    )
 
     args = parser.parse_args()
 
@@ -317,6 +323,10 @@ Examples:
                 str(orchestrator.project_dir),
                 "--auto-continue",  # Non-interactive mode for chained execution
             ]
+
+            # Pass base branch if specified (for worktree creation)
+            if args.base_branch:
+                run_cmd.extend(["--base-branch", args.base_branch])
 
             # Note: Model configuration for subsequent phases (planning, coding, qa)
             # is read from task_metadata.json by run.py, so we don't pass it here.


### PR DESCRIPTION
## Summary
- Added `--base-branch` argument to `spec_runner.py` that was missing
- The frontend was passing this argument but spec_runner didn't recognize it, causing task creation to fail
- The argument is now passed through to `run.py` when starting the build

## Problem
When creating a task from the Electron frontend with a base branch specified, users saw:
```
spec_runner.py: error: unrecognized arguments: --base-branch develop
```

## Solution
- Added `--base-branch` argument to spec_runner.py argparse
- Pass the argument to run.py when chaining to the build process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--base-branch` CLI option to specify a base branch for build operations, enabling propagation of the chosen branch into downstream build steps and more flexible worktree creation during the build phase. This helps reproduce builds against specific branches and improves reproducibility for multi-branch workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->