### PR TITLE
fix(spec_runner): add --base-branch argument support

### DIFF
--- a/apps/backend/runners/spec_runner.py
+++ b/apps/backend/runners/spec_runner.py
@@ -192,6 +192,12 @@ Examples:
         action="store_true",
         help="Skip human review checkpoint and automatically approve spec for building",
     )
+    parser.add_argument(
+        "--base-branch",
+        type=str,
+        default=None,
+        help="Base branch for creating worktrees (default: auto-detect or current branch)",
+    )
 
     args = parser.parse_args()
 
@@ -317,6 +323,10 @@ Examples:
                 str(orchestrator.project_dir),
                 "--auto-continue",  # Non-interactive mode for chained execution
             ]
+
+            # Pass base branch if specified (for worktree creation)
+            if args.base_branch:
+                run_cmd.extend(["--base-branch", args.base_branch])
 
             # Note: Model configuration for subsequent phases (planning, coding, qa)
             # is read from task_metadata.json by run.py, so we don't pass it here.


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

The frontend was passing `--base-branch` to `spec_runner.py` but the argument wasn't defined, causing task creation to fail with "unrecognized arguments: --base-branch develop". This PR adds the missing argument and passes it through to `run.py`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [x] Backend
- [ ] Fullstack

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## CI/Testing Requirements

- [ ] All CI checks pass
- [ ] All existing tests pass
- [x] New features include test coverage
- [ ] Bug fixes include regression tests

## Feature Toggle

- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--base-branch` CLI option to allow users to explicitly specify the base branch for worktree operations. When provided, this branch is passed through to subsequent run commands, enabling more precise control over branch handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->