### PR TITLE
fix(client): add spec_dir to SDK permissions

### DIFF
--- a/apps/backend/core/client.py
+++ b/apps/backend/core/client.py
@@ -182,6 +182,7 @@ def create_client(
     # Note: Using both relative paths ("./**") and absolute paths to handle
     # cases where Claude uses absolute paths for file operations
     project_path_str = str(project_dir.resolve())
+    spec_path_str = str(spec_dir.resolve())
     security_settings = {
         "sandbox": {"enabled": True, "autoAllowBashIfSandboxed": True},
         "permissions": {
@@ -200,6 +201,10 @@ def create_client(
                 f"Edit({project_path_str}/**)",
                 f"Glob({project_path_str}/**)",
                 f"Grep({project_path_str}/**)",
+                # Allow spec directory explicitly (needed when spec is in worktree)
+                f"Read({spec_path_str}/**)",
+                f"Write({spec_path_str}/**)",
+                f"Edit({spec_path_str}/**)",
                 # Bash permission granted here, but actual commands are validated
                 # by the bash_security_hook (see security.py for allowed commands)
                 "Bash(*)",


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

When running in isolated mode (worktree), the spec directory may be outside the project_dir path. This caused permission errors when the agent tried to write to `implementation_plan.json` or other spec files in the worktree's spec directory.

Added explicit Read/Write/Edit permissions for spec_dir path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [x] Backend
- [ ] Fullstack

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## CI/Testing Requirements

- [ ] All CI checks pass
- [ ] All existing tests pass
- [x] New features include test coverage
- [ ] Bug fixes include regression tests

## Feature Toggle

- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission issues preventing proper access to specification files, ensuring consistent read/write/edit capabilities across specification and project directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->