### PR TITLE
Fix: Python path handling for paths with spaces

### DIFF
--- a/auto-claude-ui/src/main/python-detector.ts
+++ b/auto-claude-ui/src/main/python-detector.ts
@@ -50,10 +50,17 @@ export function getDefaultPythonCommand(): string {
  * Parse a Python command string into command and base arguments.
  * Handles space-separated commands like "py -3".
  *
- * @param pythonPath - The Python command string (e.g., "python3", "py -3")
+ * @param pythonPath - The Python command string (e.g., "python3", "py -3", "/path/to/python")
  * @returns Tuple of [command, baseArgs] ready for use with spawn()
  */
 export function parsePythonCommand(pythonPath: string): [string, string[]] {
+  // If it's a file path (contains / or \), don't split on spaces
+  // This handles paths like "/Users/mrt/Library/Application Support/venv/bin/python"
+  if (pythonPath.includes('/') || pythonPath.includes('\\')) {
+    return [pythonPath, []];
+  }
+
+  // Otherwise, split on spaces to handle commands like "py -3"
   const parts = pythonPath.split(' ');
   const command = parts[0];
   const baseArgs = parts.slice(1);


### PR DESCRIPTION
## Problem
The `parsePythonCommand` function was splitting Python paths on spaces, causing failures when the Python venv is located in a directory with spaces (e.g., `/Users/name/Library/Application Support/auto-claude-ui/python-venv/bin/python`).

This resulted in spawn errors like:
```
spawn /Users/mrt/Library/Application ENOENT
```

## Solution
Updated `parsePythonCommand` in `src/main/python-detector.ts` to detect file paths (containing `/` or `\`) and avoid splitting them on spaces.

## Changes
- Added path detection logic before splitting on spaces
- Paths with `/` or `\` are returned as-is with no splitting
- Space-separated commands like `py -3` still work correctly

## Testing
- ✅ Tested on macOS with venv in `~/Library/Application Support/auto-claude-ui/python-venv/`
- ✅ Merge operations now work correctly
- ✅ No regression for simple commands like `python3` or `py -3`

## Impact
Fixes merge/stage operations for users on macOS (and potentially Windows) who have Python environments in paths with spaces.