### PR TITLE
feat(frontend): add configurable dev server port and DevTools

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -42,3 +42,9 @@
 
 # Node environment (automatically set by npm scripts)
 # NODE_ENV=development
+
+# Vite dev server port (default: 5173)
+# VITE_DEV_PORT=5173
+
+# Auto-open Chrome DevTools in dev mode (default: true)
+# OPEN_DEVTOOLS=false

--- a/apps/frontend/electron.vite.config.ts
+++ b/apps/frontend/electron.vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import { config as loadEnvFile } from 'dotenv';
+
+loadEnvFile({ quiet: true });
 
 export default defineConfig({
   main: {
@@ -55,6 +58,7 @@ export default defineConfig({
       }
     },
     server: {
+      port: Number(process.env.VITE_DEV_PORT) || 5173,
       watch: {
         // Ignore directories to prevent HMR conflicts during merge operations
         // Using absolute paths and broader patterns

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -114,6 +114,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "autoprefixer": "^10.4.22",
     "cross-env": "^10.1.0",
+    "dotenv": "^17.2.3",
     "electron": "39.2.7",
     "electron-builder": "^26.0.12",
     "electron-vite": "^5.0.0",

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -93,7 +93,7 @@ function createWindow(): void {
   }
 
   // Open DevTools in development
-  if (is.dev) {
+  if (is.dev && process.env.OPEN_DEVTOOLS !== 'false') {
     mainWindow.webContents.openDevTools({ mode: 'right' });
   }
 


### PR DESCRIPTION
## Summary
Add configurable environment variables for frontend development flexibility.

## Changes
- **VITE_DEV_PORT**: Customize the Vite dev server port (default: 5173)
- **OPEN_DEVTOOLS**: Control whether DevTools auto-opens in dev mode (default: true, set to 'false' to disable)

## Files Modified
- `apps/frontend/.env.example` - Document new env vars
- `apps/frontend/electron.vite.config.ts` - Load dotenv and use VITE_DEV_PORT
- `apps/frontend/src/main/index.ts` - Respect OPEN_DEVTOOLS setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev server port can be configured via environment variable (default 5173).
  * DevTools now open only in development and when OPEN_DEVTOOLS is not set to 'false'.

* **Documentation**
  * Example environment configuration updated with the two new options.

* **Chores**
  * Added a development dependency to support loading environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->