### PR TITLE
fix(pr-review): treat LOW-only findings as ready to merge

### DIFF
--- a/apps/backend/runners/github/orchestrator.py
+++ b/apps/backend/runners/github/orchestrator.py
@@ -799,9 +799,11 @@ class GitHubOrchestrator:
             if low:
                 reasoning += f", {len(low)} suggestions"
         elif low:
-            # Only Low severity suggestions - can merge but consider addressing
-            verdict = MergeVerdict.MERGE_WITH_CHANGES
-            reasoning = f"{len(low)} suggestion(s) to consider"
+            # Only Low severity suggestions - safe to merge (non-blocking)
+            verdict = MergeVerdict.READY_TO_MERGE
+            reasoning = (
+                f"No blocking issues. {len(low)} non-blocking suggestion(s) to consider"
+            )
         else:
             verdict = MergeVerdict.READY_TO_MERGE
             reasoning = "No blocking issues found"

--- a/apps/backend/runners/github/services/followup_reviewer.py
+++ b/apps/backend/runners/github/services/followup_reviewer.py
@@ -485,11 +485,11 @@ class FollowupReviewer:
                 f"({high_unresolved + medium_unresolved} unresolved, {high_new + medium_new} new)"
             )
         elif low_unresolved > 0 or low_new > 0:
-            # Only Low severity suggestions remaining - can merge but consider addressing
-            verdict = MergeVerdict.MERGE_WITH_CHANGES
+            # Only Low severity suggestions remaining - safe to merge (non-blocking)
+            verdict = MergeVerdict.READY_TO_MERGE
             reasoning = (
                 f"{resolved_count} issues resolved. "
-                f"{low_unresolved + low_new} suggestion(s) to consider."
+                f"{low_unresolved + low_new} non-blocking suggestion(s) to consider."
             )
         else:
             verdict = MergeVerdict.READY_TO_MERGE

--- a/apps/backend/runners/github/services/parallel_orchestrator_reviewer.py
+++ b/apps/backend/runners/github/services/parallel_orchestrator_reviewer.py
@@ -743,9 +743,11 @@ The SDK will run invoked agents in parallel automatically.
             if low:
                 reasoning += f", {len(low)} suggestions"
         elif low:
-            # Only Low severity suggestions - can merge but consider addressing
-            verdict = MergeVerdict.MERGE_WITH_CHANGES
-            reasoning = f"{len(low)} suggestion(s) to consider"
+            # Only Low severity suggestions - safe to merge (non-blocking)
+            verdict = MergeVerdict.READY_TO_MERGE
+            reasoning = (
+                f"No blocking issues. {len(low)} non-blocking suggestion(s) to consider"
+            )
         else:
             verdict = MergeVerdict.READY_TO_MERGE
             reasoning = "No blocking issues found"


### PR DESCRIPTION
## Summary

- LOW severity findings are explicitly non-blocking suggestions, but verdict logic returned `MERGE_WITH_CHANGES` instead of `READY_TO_MERGE`
- Updated verdict determination in `followup_reviewer`, `orchestrator`, and `parallel_orchestrator_reviewer` to return `READY_TO_MERGE` when only LOW severity findings remain
- Reasoning text now says "non-blocking suggestion(s)" to clarify these are optional

## Verdict Logic (after fix)

| Severity | Verdict |
|----------|---------|
| CRITICAL | BLOCKED |
| HIGH or MEDIUM | NEEDS_REVISION |
| LOW only | ✅ READY_TO_MERGE |
| None | READY_TO_MERGE |

## Test plan

- [x] All 1196 tests pass
- [ ] Verify follow-up review with only LOW findings shows "Ready to Merge"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated pull request review verdicts to mark reviews with only low-severity findings as ready to merge.
  * Clarified messaging to indicate low-severity findings are non-blocking suggestions rather than required changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->