### PR TITLE
fix(ui): increase Edit Task dialog size for better UX

### DIFF
--- a/auto-claude-ui/src/renderer/components/TaskEditDialog.tsx
+++ b/auto-claude-ui/src/renderer/components/TaskEditDialog.tsx
@@ -461,7 +461,7 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[550px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-foreground">Edit Task</DialogTitle>
           <DialogDescription>
@@ -485,7 +485,7 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
               onDragOver={handleTextareaDragOver}
               onDragLeave={handleTextareaDragLeave}
               onDrop={handleTextareaDrop}
-              rows={5}
+              rows={8}
               disabled={isSaving}
               className={cn(
                 isDragOverTextarea && !isSaving && "border-primary bg-primary/5 ring-2 ring-primary/20"


### PR DESCRIPTION
## Summary
Increases the Edit Task dialog size to provide better UX for editing task descriptions.

Fixes #493

## Problem
The Edit Task popup was too small (550px max-width, 5 rows for description textarea), making it difficult to edit longer task descriptions. Users had to scroll unnecessarily within a small editing area.

## Solution
- Increased dialog max-width from **550px → 700px** (consistent with LinearTaskImport dialog)
- Increased description textarea from **5 → 8 rows**

## Before/After
| Before | After |
|--------|-------|
| 550px width, 5 rows | 700px width, 8 rows |
| Cramped editing space | More room for content |

## Test plan
- [x] TypeScript compiles without errors
- [x] Dialog opens at new size
- [x] Description textarea has more visible rows
- [x] All form elements remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
