### PR TITLE
fix(node-detector): add PATH enhancement for npm/npx discovery

### DIFF
--- a/auto-claude-ui/package-lock.json
+++ b/auto-claude-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-claude-ui",
-  "version": "2.6.5",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-claude-ui",
-      "version": "2.6.5",
+      "version": "2.7.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -40,7 +40,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron-updater": "^6.6.2",
-        "kuzu": "^0.8.2",
         "lucide-react": "^0.560.0",
         "motion": "^12.23.26",
         "react": "^19.2.3",
@@ -4824,6 +4823,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4833,6 +4833,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4927,26 +4928,6 @@
       },
       "engines": {
         "node": ">=12.13.0"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/argparse": {
@@ -5179,6 +5160,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -5242,17 +5224,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/bail": {
@@ -5565,6 +5536,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5718,6 +5690,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -5816,6 +5789,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5858,50 +5832,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/cmake-js": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.4.0.tgz",
-      "integrity": "sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.5",
-        "debug": "^4",
-        "fs-extra": "^11.2.0",
-        "memory-stream": "^1.0.0",
-        "node-api-headers": "^1.1.0",
-        "npmlog": "^6.0.2",
-        "rc": "^1.2.7",
-        "semver": "^7.5.4",
-        "tar": "^6.2.0",
-        "url-join": "^4.0.1",
-        "which": "^2.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "cmake-js": "bin/cmake-js"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5914,16 +5849,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -5936,6 +5863,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6048,12 +5976,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6271,15 +6193,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6350,16 +6263,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -6530,6 +6438,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6772,6 +6681,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding": {
@@ -6925,6 +6835,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6934,6 +6845,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6978,6 +6890,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6990,6 +6903,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7086,6 +7000,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7575,26 +7490,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7645,6 +7540,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7716,6 +7612,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -7750,6 +7647,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7786,26 +7684,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -7830,6 +7708,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7852,6 +7731,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7885,6 +7765,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8038,6 +7919,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8134,6 +8016,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8146,6 +8029,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8157,16 +8041,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8485,12 +8364,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -8736,6 +8610,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9055,6 +8930,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -9270,24 +9146,6 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
-    },
-    "node_modules/kuzu": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/kuzu/-/kuzu-0.8.2.tgz",
-      "integrity": "sha512-GdaDfutKf/MXZQYZwhpupnUJLODbLheplzNUWy0CgU4HW/Yk8AYij7K4/FP8G/zlNNvn8pNP/jj19bg0vCwcYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "cmake-js": "^7.3.0",
-        "node-addon-api": "^6.0.0"
-      }
-    },
-    "node_modules/kuzu/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -10216,6 +10074,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10501,15 +10360,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/memory-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
-      "integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/micromark": {
@@ -11119,6 +10969,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -11128,6 +10979,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11189,6 +11041,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11198,6 +11051,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11280,12 +11134,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -11299,12 +11155,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -11430,12 +11288,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/node-api-headers": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.7.0.tgz",
-      "integrity": "sha512-uJMGdkhVwu9+I3UsVvI3KW6ICAy/yDfsu5Br9rSnTtY3WpoaComXvKloiV5wtx0Md2rn0B9n29Ys2WMNwWxj9A==",
-      "license": "MIT"
-    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -11480,22 +11332,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/nwsapi": {
@@ -12206,12 +12042,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -12244,30 +12074,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -12431,6 +12237,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -12568,6 +12375,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12814,6 +12622,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12943,12 +12752,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -13109,6 +12912,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
@@ -13298,6 +13102,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13317,6 +13122,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13459,6 +13265,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13592,6 +13399,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -13609,6 +13417,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -13618,6 +13427,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/temp": {
@@ -14241,12 +14051,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "license": "MIT"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -15087,6 +14891,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15204,15 +15009,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -15227,6 +15023,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -15319,6 +15116,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -15351,6 +15149,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -15369,6 +15168,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/auto-claude-ui/src/__tests__/unit/node-detector.test.ts
+++ b/auto-claude-ui/src/__tests__/unit/node-detector.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for node-detector module
+ * Tests PATH enhancement for npm/npx discovery
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process before importing the module
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+// Mock fs
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+import { existsSync, readdirSync } from 'fs';
+import { findNodeBinPath, getEnhancedPath, isNodeAvailable } from '../../main/node-detector';
+
+describe('node-detector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('findNodeBinPath', () => {
+    it('should find npx via which command', () => {
+      vi.mocked(execSync).mockReturnValueOnce('/usr/local/bin/npx\n');
+      vi.mocked(existsSync).mockReturnValueOnce(true);
+
+      const result = findNodeBinPath();
+      expect(result).toBe('/usr/local/bin');
+    });
+
+    it('should return null when npx not found anywhere', () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('not found');
+      });
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = findNodeBinPath();
+      expect(result).toBeNull();
+    });
+
+    it('should check common paths when which fails', () => {
+      // which fails
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('not found');
+      });
+      // existsSync returns true for /usr/local/bin/npx
+      vi.mocked(existsSync).mockImplementation((p: string) => {
+        return p.includes('/usr/local/bin/npx');
+      });
+
+      const result = findNodeBinPath();
+      expect(result).toBe('/usr/local/bin');
+    });
+  });
+
+  describe('getEnhancedPath', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv, PATH: '/usr/bin:/bin' };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should prepend node bin path to existing PATH', () => {
+      vi.mocked(execSync).mockReturnValueOnce('/usr/local/bin/npx\n');
+      vi.mocked(existsSync).mockReturnValueOnce(true);
+
+      const result = getEnhancedPath();
+      expect(result).toBe('/usr/local/bin:/usr/bin:/bin');
+    });
+
+    it('should not duplicate path if already present', () => {
+      process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+      vi.mocked(execSync).mockReturnValueOnce('/usr/local/bin/npx\n');
+      vi.mocked(existsSync).mockReturnValueOnce(true);
+
+      const result = getEnhancedPath();
+      expect(result).toBe('/usr/local/bin:/usr/bin:/bin');
+    });
+
+    it('should return original PATH when node not found', () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('not found');
+      });
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = getEnhancedPath();
+      expect(result).toBe('/usr/bin:/bin');
+    });
+  });
+
+  describe('isNodeAvailable', () => {
+    it('should return true when npx is available', () => {
+      // First call is for findNodeBinPath (via getEnhancedPath), second is for npx --version
+      vi.mocked(execSync)
+        .mockReturnValueOnce('/usr/local/bin/npx\n')  // findNodeBinPath
+        .mockReturnValueOnce('10.2.0\n');              // npx --version
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = isNodeAvailable();
+      expect(result).toBe(true);
+    });
+
+    it('should return false when npx is not available', () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('not found');
+      });
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = isNodeAvailable();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/auto-claude-ui/src/main/agent/agent-process.ts
+++ b/auto-claude-ui/src/main/agent/agent-process.ts
@@ -10,6 +10,7 @@ import { detectRateLimit, createSDKRateLimitInfo, getProfileEnv, detectAuthFailu
 import { projectStore } from '../project-store';
 import { getClaudeProfileManager } from '../claude-profile-manager';
 import { findPythonCommand, parsePythonCommand } from '../python-detector';
+import { getEnhancedPath } from '../node-detector';
 
 /**
  * Process spawning and lifecycle management
@@ -171,6 +172,9 @@ export class AgentProcessManager {
         ...process.env,
         ...extraEnv,
         ...profileEnv, // Include active Claude profile config
+        // Enhance PATH to include Node.js bin directory for MCP servers using npx/npm
+        // This fixes "npx not found" errors when Electron doesn't inherit shell PATH
+        PATH: getEnhancedPath(),
         PYTHONUNBUFFERED: '1', // Ensure real-time output
         PYTHONIOENCODING: 'utf-8', // Ensure UTF-8 encoding on Windows
         PYTHONUTF8: '1' // Force Python UTF-8 mode on Windows (Python 3.7+)

--- a/auto-claude-ui/src/main/node-detector.ts
+++ b/auto-claude-ui/src/main/node-detector.ts
@@ -1,0 +1,158 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Common paths where Node.js/npm might be installed.
+ * These paths are checked when the default PATH doesn't include npm/npx.
+ */
+const COMMON_NODE_PATHS = {
+  darwin: [
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+    `${os.homedir()}/.nvm/versions/node`, // nvm installations
+    `${os.homedir()}/.fnm/node-versions`, // fnm installations
+    `${os.homedir()}/.volta/bin`, // volta installations
+    `${os.homedir()}/.asdf/shims`, // asdf installations
+    '/usr/bin',
+  ],
+  linux: [
+    '/usr/local/bin',
+    '/usr/bin',
+    `${os.homedir()}/.nvm/versions/node`,
+    `${os.homedir()}/.fnm/node-versions`,
+    `${os.homedir()}/.volta/bin`,
+    `${os.homedir()}/.asdf/shims`,
+    `${os.homedir()}/.local/bin`,
+  ],
+  win32: [
+    `${process.env.APPDATA}\\npm`,
+    `${process.env.PROGRAMFILES}\\nodejs`,
+    `${process.env.LOCALAPPDATA}\\Programs\\nodejs`,
+    `${os.homedir()}\\AppData\\Roaming\\nvm`, // nvm-windows
+  ],
+};
+
+/**
+ * Find the directory containing npm/npx executables.
+ * This is necessary because Electron apps launched from Finder/Spotlight
+ * don't inherit the user's shell PATH modifications.
+ *
+ * @returns The directory containing npm/npx, or null if not found
+ */
+export function findNodeBinPath(): string | null {
+  const isWindows = process.platform === 'win32';
+  const npxName = isWindows ? 'npx.cmd' : 'npx';
+
+  // First, try to find npx in the current PATH
+  try {
+    const whichCmd = isWindows ? 'where npx' : 'which npx';
+    const result = execSync(whichCmd, {
+      stdio: 'pipe',
+      timeout: 5000,
+      windowsHide: true,
+      encoding: 'utf-8',
+    }).trim();
+
+    if (result) {
+      // Return the directory containing npx
+      const lines = result.split(/\r?\n/);
+      const firstResult = lines[0];
+      if (firstResult && existsSync(firstResult)) {
+        return path.dirname(firstResult);
+      }
+    }
+  } catch {
+    // npx not in PATH, continue to check common paths
+  }
+
+  // Check common installation paths
+  const platform = process.platform as keyof typeof COMMON_NODE_PATHS;
+  const commonPaths = COMMON_NODE_PATHS[platform] || [];
+
+  for (const basePath of commonPaths) {
+    // Handle version managers (nvm, fnm) that have version subdirectories
+    if (basePath.includes('nvm/versions/node') || basePath.includes('fnm/node-versions')) {
+      try {
+        // Find the most recent Node version directory
+        const { readdirSync } = require('fs');
+        if (existsSync(basePath)) {
+          const versions = readdirSync(basePath)
+            .filter((v: string) => v.startsWith('v'))
+            .sort()
+            .reverse();
+
+          for (const version of versions) {
+            const binPath = path.join(basePath, version, 'bin');
+            const npxPath = path.join(binPath, npxName);
+            if (existsSync(npxPath)) {
+              return binPath;
+            }
+          }
+        }
+      } catch {
+        // Directory doesn't exist or can't be read
+        continue;
+      }
+    } else {
+      // Direct path check
+      const npxPath = path.join(basePath, npxName);
+      if (existsSync(npxPath)) {
+        return basePath;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get an enhanced PATH environment variable that includes Node.js bin directory.
+ * This ensures npm/npx can be found even when Electron doesn't inherit the shell PATH.
+ *
+ * @returns Enhanced PATH string with Node.js bin directory prepended
+ */
+export function getEnhancedPath(): string {
+  const currentPath = process.env.PATH || '';
+  const nodeBinPath = findNodeBinPath();
+
+  if (!nodeBinPath) {
+    return currentPath;
+  }
+
+  // Check if the path is already included
+  const pathSep = process.platform === 'win32' ? ';' : ':';
+  const pathParts = currentPath.split(pathSep);
+
+  if (pathParts.includes(nodeBinPath)) {
+    return currentPath;
+  }
+
+  // Prepend the Node bin path so it takes precedence
+  return `${nodeBinPath}${pathSep}${currentPath}`;
+}
+
+/**
+ * Check if npm/npx is available in the current or enhanced PATH.
+ *
+ * @returns true if npx is available, false otherwise
+ */
+export function isNodeAvailable(): boolean {
+  const isWindows = process.platform === 'win32';
+
+  try {
+    execSync(isWindows ? 'npx --version' : 'npx --version', {
+      stdio: 'pipe',
+      timeout: 5000,
+      windowsHide: true,
+      env: {
+        ...process.env,
+        PATH: getEnhancedPath(),
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the "Command 'npx' not found in PATH" error when adding custom MCP servers or using built-in MCP servers that rely on npx/npm.

Fixes #523

## Problem
Electron apps launched from Finder/Spotlight on macOS (or Start Menu on Windows) don't inherit the user's shell PATH modifications. This means:
- PATH from `.bashrc`, `.zshrc` is not available
- Node version managers (nvm, fnm, volta, asdf) paths are missing
- Common locations like `/usr/local/bin`, `/opt/homebrew/bin` may be missing

When the Claude Agent SDK spawns MCP servers using `npx` commands (e.g., context7, puppeteer-mcp-server), it fails because npx is not in the PATH.

## Solution
Created a new `node-detector.ts` module that:

1. **Finds npm/npx installation**: Checks the current PATH first, then common installation locations:
   - `/usr/local/bin`, `/opt/homebrew/bin` (Homebrew on macOS)
   - `~/.nvm/versions/node/*/bin` (nvm)
   - `~/.fnm/node-versions/*/bin` (fnm)
   - `~/.volta/bin` (Volta)
   - `~/.asdf/shims` (asdf)
   - Windows equivalents

2. **Enhances PATH**: `getEnhancedPath()` returns the current PATH with the Node.js bin directory prepended

3. **Integrates with agent spawning**: `agent-process.ts` now passes the enhanced PATH to Python processes, which flows through to the Claude Agent SDK when spawning MCP servers

## Test plan
- [x] TypeScript compiles without errors
- [x] All 8 new unit tests pass
- [x] Tested on macOS with Homebrew-installed Node.js

## Changes
- `auto-claude-ui/src/main/node-detector.ts`: New module for finding npm/npx paths
- `auto-claude-ui/src/main/agent/agent-process.ts`: Use enhanced PATH when spawning
- `auto-claude-ui/src/__tests__/unit/node-detector.test.ts`: Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
