### PR TITLE
fix(mcp): use shell mode for Windows command spawning

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/mcp-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/mcp-handlers.ts
@@ -188,7 +188,7 @@ async function checkCommandHealth(server: CustomMcpServer, startTime: number): P
       return resolve({
         serverId: server.id,
         status: 'unhealthy',
-        message: 'Args contain dangerous interpreter flags',
+        message: 'Args contain dangerous flags or shell metacharacters',
         checkedAt: new Date().toISOString(),
       });
     }
@@ -411,7 +411,7 @@ async function testCommandConnection(server: CustomMcpServer, startTime: number)
       return resolve({
         serverId: server.id,
         success: false,
-        message: 'Args contain dangerous interpreter flags',
+        message: 'Args contain dangerous flags or shell metacharacters',
       });
     }
 


### PR DESCRIPTION
## Summary

On Windows, commands like `npx`, `npm`, `node`, etc. are actually batch scripts (e.g., `npx.cmd`). When spawning these without `shell: true`, Node.js fails to execute them properly because it tries to run them as direct executables.

This fix adds `shell: true` on Windows platform for MCP server connection testing, allowing command-based MCP servers (like perplexity-ask, logfire, etc.) to start correctly.

## Problem

Windows users configuring custom MCP servers with commands like:
- `npx -yq @perplexity-ai/mcp-server`
- `uvx logfire-mcp`

Would see "Failed to start server" errors because the spawn call couldn't execute `.cmd` batch scripts without a shell.

## Solution

Added `shell: process.platform === 'win32'` to the spawn options in `testCommandConnection()`. This is a targeted fix that only enables shell mode on Windows, preserving the current behavior on macOS/Linux.

## Changes

- `apps/frontend/src/main/ipc-handlers/mcp-handlers.ts`: Added `shell: true` for Windows in the spawn call

## Test Plan

- [x] Tested on Windows 11 with perplexity-ask MCP server
- [x] Server connection test now succeeds
- [x] MCP server responds to initialize request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened command execution on Windows by validating arguments to block dangerous shell metacharacters and interpreter flags.
  * Improved reliability of Windows command/batch script execution by enabling appropriate shell handling where needed.
  * Clarified health and connection messages to indicate when arguments contain dangerous flags or shell metacharacters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->