### PR TITLE
fix(kanban): complete refresh button implementation

### DIFF
--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -277,7 +277,7 @@ const DroppableColumn = memo(function DroppableColumn({ status, tasks, onTaskCli
   );
 }, droppableColumnPropsAreEqual);
 
-export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick }: KanbanBoardProps) {
+export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isRefreshing }: KanbanBoardProps) {
   const { t } = useTranslation('tasks');
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [overColumnId, setOverColumnId] = useState<string | null>(null);
@@ -412,6 +412,21 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick }: KanbanBoardP
 
   return (
     <div className="flex h-full flex-col">
+      {/* Kanban header with refresh button */}
+      {onRefresh && (
+        <div className="flex items-center justify-end px-6 pt-4 pb-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            className="gap-2 text-muted-foreground hover:text-foreground"
+          >
+            <RefreshCw className={cn("h-4 w-4", isRefreshing && "animate-spin")} />
+            {isRefreshing ? 'Refreshing...' : 'Refresh Tasks'}
+          </Button>
+        </div>
+      )}
       {/* Kanban columns */}
       <DndContext
         sensors={sensors}


### PR DESCRIPTION
## Summary
Completes the refresh button implementation from PR #548 which was merged with incomplete code.

## Problem
PR #548 added `onRefresh` and `isRefreshing` props to KanbanBoard's interface and imported `RefreshCw` icon, but:
- Props were never destructured in the function signature
- No button was rendered using the icon

This left users unable to manually refresh tasks when the UI gets stuck.

## Changes
- Destructure `onRefresh` and `isRefreshing` props in `KanbanBoard` function
- Add refresh button in kanban header with:
  - Spinning animation while refreshing
  - "Refreshing..." text during loading
  - Ghost variant styling to match existing UI

## Testing
- Verified button appears in Kanban view
- Confirmed clicking triggers task reload
- Spinning animation works during refresh



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh control to the Kanban board to reload tasks. The control is disabled while a refresh is in progress, displays a spinner, and toggles its label between an active and loading state to indicate progress.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->