### PR TITLE
fix: persist Ideation running state across navigation

### DIFF
--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -57,6 +57,7 @@ import { useClaudeProfileStore } from './stores/claude-profile-store';
 import { useTerminalStore, restoreTerminalSessions } from './stores/terminal-store';
 import { initializeGitHubListeners } from './stores/github';
 import { initDownloadProgressListener } from './stores/download-store';
+import { setupIdeationListeners } from './stores/ideation-store';
 import { GlobalDownloadIndicator } from './components/GlobalDownloadIndicator';
 import { useIpcListeners } from './hooks/useIpc';
 import { COLOR_THEMES, UI_SCALE_MIN, UI_SCALE_MAX, UI_SCALE_DEFAULT } from '../shared/constants';
@@ -181,9 +182,12 @@ export function App() {
     initializeGitHubListeners();
     // Initialize global download progress listener for Ollama model downloads
     const cleanupDownloadListener = initDownloadProgressListener();
+    // Initialize global Ideation IPC listeners so they persist across navigation
+    const cleanupIdeationListeners = setupIdeationListeners();
 
     return () => {
       cleanupDownloadListener();
+      cleanupIdeationListeners();
     };
   }, []);
 
@@ -766,8 +770,15 @@ export function App() {
                 {activeView === 'context' && (activeProjectId || selectedProjectId) && (
                   <Context projectId={activeProjectId || selectedProjectId!} />
                 )}
-                {activeView === 'ideation' && (activeProjectId || selectedProjectId) && (
-                  <Ideation projectId={activeProjectId || selectedProjectId!} onGoToTask={handleGoToTask} />
+                {/* Ideation - Always mounted but hidden when not active to preserve running state */}
+                {(activeProjectId || selectedProjectId) && (
+                  <div className={activeView === 'ideation' ? 'h-full' : 'hidden'}>
+                    <Ideation
+                      projectId={activeProjectId || selectedProjectId!}
+                      onGoToTask={handleGoToTask}
+                      isActive={activeView === 'ideation'}
+                    />
+                  </div>
                 )}
                 {activeView === 'insights' && (activeProjectId || selectedProjectId) && (
                   <Insights projectId={activeProjectId || selectedProjectId!} />

--- a/apps/frontend/src/renderer/components/Sidebar.tsx
+++ b/apps/frontend/src/renderer/components/Sidebar.tsx
@@ -20,7 +20,8 @@ import {
   Sparkles,
   GitBranch,
   HelpCircle,
-  Wrench
+  Wrench,
+  Loader2
 } from 'lucide-react';
 import { Button } from './ui/button';
 import { ScrollArea } from './ui/scroll-area';
@@ -46,6 +47,7 @@ import {
   initializeProject
 } from '../stores/project-store';
 import { useSettingsStore } from '../stores/settings-store';
+import { useIdeationStore } from '../stores/ideation-store';
 import { AddProjectModal } from './AddProjectModal';
 import { GitSetupModal } from './GitSetupModal';
 import { RateLimitIndicator } from './RateLimitIndicator';
@@ -104,6 +106,7 @@ export function Sidebar({
   const selectedProjectId = useProjectStore((state) => state.selectedProjectId);
   const selectProject = useProjectStore((state) => state.selectProject);
   const settings = useSettingsStore((state) => state.settings);
+  const ideationRunning = useIdeationStore((state) => state.isGenerating);
 
   const [showAddProjectModal, setShowAddProjectModal] = useState(false);
   const [showInitDialog, setShowInitDialog] = useState(false);
@@ -270,6 +273,7 @@ export function Sidebar({
   const renderNavItem = (item: NavItem) => {
     const isActive = activeView === item.id;
     const Icon = item.icon;
+    const isIdeationRunning = item.id === 'ideation' && ideationRunning;
 
     return (
       <button
@@ -285,10 +289,16 @@ export function Sidebar({
       >
         <Icon className="h-4 w-4 shrink-0" />
         <span className="flex-1 text-left">{t(item.labelKey)}</span>
-        {item.shortcut && (
+        {item.shortcut && !isIdeationRunning && (
           <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded-md border border-border bg-secondary px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:flex">
             {item.shortcut}
           </kbd>
+        )}
+        {isIdeationRunning && (
+          <div className="hidden sm:flex items-center gap-1.5">
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-400" />
+            <span className="text-[10px] font-medium text-blue-400">{t('common:labels.progress')}</span>
+          </div>
         )}
       </button>
     );

--- a/apps/frontend/src/renderer/components/ideation/Ideation.tsx
+++ b/apps/frontend/src/renderer/components/ideation/Ideation.tsx
@@ -15,9 +15,10 @@ import { ALL_IDEATION_TYPES } from './constants';
 interface IdeationProps {
   projectId: string;
   onGoToTask?: (taskId: string) => void;
+  isActive?: boolean;
 }
 
-export function Ideation({ projectId, onGoToTask }: IdeationProps) {
+export function Ideation({ projectId, onGoToTask, isActive = true }: IdeationProps) {
   // Get showArchived from shared context for cross-page sync
   const { showArchived } = useViewState();
 

--- a/apps/frontend/src/renderer/components/ideation/hooks/useIdeation.ts
+++ b/apps/frontend/src/renderer/components/ideation/hooks/useIdeation.ts
@@ -51,11 +51,9 @@ export function useIdeation(projectId: string, options: UseIdeationOptions = {})
 
   const { hasToken, isLoading: isCheckingToken, checkToken } = useClaudeTokenCheck();
 
-  // Set up IPC listeners and load ideation on mount
+  // Load ideation on mount (IPC listeners are now global, set up in App.tsx)
   useEffect(() => {
-    const cleanup = setupIdeationListeners();
     loadIdeation(projectId);
-    return cleanup;
   }, [projectId]);
 
   const handleGenerate = async () => {

--- a/apps/frontend/src/renderer/stores/ideation-store.ts
+++ b/apps/frontend/src/renderer/stores/ideation-store.ts
@@ -9,6 +9,9 @@ import type {
   IdeationSummary
 } from '../../shared/types';
 import { DEFAULT_IDEATION_CONFIG } from '../../shared/constants';
+import { toast } from '../hooks/use-toast';
+import { useRoadmapStore } from './roadmap-store';
+import i18next from 'i18next';
 
 const GENERATION_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -397,6 +400,20 @@ export async function loadIdeation(projectId: string): Promise<void> {
 export function generateIdeation(projectId: string): void {
   const store = useIdeationStore.getState();
   const config = store.config;
+
+  // Check if Roadmap is running
+  const roadmapState = useRoadmapStore.getState();
+  const roadmapRunning = roadmapState.generationStatus.phase !== 'idle' &&
+                         roadmapState.generationStatus.phase !== 'complete' &&
+                         roadmapState.generationStatus.phase !== 'error';
+
+  if (roadmapRunning) {
+    toast({
+      title: i18next.t('common:warnings.concurrentRoadmap'),
+      description: i18next.t('common:warnings.concurrentRoadmapDesc'),
+      variant: 'default',
+    });
+  }
 
   if (window.DEBUG) {
     console.log('[Ideation] Starting generation:', {

--- a/apps/frontend/src/renderer/stores/roadmap-store.ts
+++ b/apps/frontend/src/renderer/stores/roadmap-store.ts
@@ -7,6 +7,9 @@ import type {
   RoadmapGenerationStatus,
   FeatureSource
 } from '../../shared/types';
+import { toast } from '../hooks/use-toast';
+import { useIdeationStore } from './ideation-store';
+import i18next from 'i18next';
 
 /**
  * Migrate roadmap data to latest schema
@@ -299,6 +302,16 @@ export function generateRoadmap(
   enableCompetitorAnalysis?: boolean,
   refreshCompetitorAnalysis?: boolean
 ): void {
+  // Check if Ideation is running
+  const ideationState = useIdeationStore.getState();
+  if (ideationState.isGenerating) {
+    toast({
+      title: i18next.t('common:warnings.concurrentIdeation'),
+      description: i18next.t('common:warnings.concurrentIdeationDesc'),
+      variant: 'default',
+    });
+  }
+
   // Debug logging
   if (window.DEBUG) {
     console.log('[Roadmap] Starting generation:', { projectId, enableCompetitorAnalysis, refreshCompetitorAnalysis });

--- a/apps/frontend/src/shared/i18n/locales/en/common.json
+++ b/apps/frontend/src/shared/i18n/locales/en/common.json
@@ -40,7 +40,14 @@
     "noData": "No data",
     "optional": "Optional",
     "required": "Required",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "progress": "progress"
+  },
+  "warnings": {
+    "concurrentRoadmap": "Roadmap generation is running",
+    "concurrentRoadmapDesc": "Starting Ideation may slow down both processes.",
+    "concurrentIdeation": "Ideation generation is running",
+    "concurrentIdeationDesc": "Starting Roadmap may slow down both processes."
   },
   "time": {
     "justNow": "Just now",

--- a/apps/frontend/src/shared/i18n/locales/fr/common.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/common.json
@@ -40,7 +40,14 @@
     "noData": "Aucune donnée",
     "optional": "Optionnel",
     "required": "Requis",
-    "dismiss": "Ignorer"
+    "dismiss": "Ignorer",
+    "progress": "en cours"
+  },
+  "warnings": {
+    "concurrentRoadmap": "La génération de la feuille de route est en cours",
+    "concurrentRoadmapDesc": "Démarrer l'idéation peut ralentir les deux processus.",
+    "concurrentIdeation": "La génération d'idéation est en cours",
+    "concurrentIdeationDesc": "Démarrer la feuille de route peut ralentir les deux processus."
   },
   "time": {
     "justNow": "À l'instant",


### PR DESCRIPTION
## Summary

Fixes the issue where Ideation generation state is lost when navigating away from the Ideation view and returning to it. The background Python process continues running, but there's no visual indication of progress in the UI.

## Changes

### Architecture
- **Convert Ideation to always-mounted pattern**: Component stays mounted but hidden with CSS (`className={activeView === 'ideation' ? 'h-full' : 'hidden'}`) to preserve state during navigation
- **Move IPC listeners to global scope**: Listeners now initialize in `App.tsx` instead of per-component mount, preventing listener destruction on navigation

### UI Improvements
- **Sidebar progress indicator**: Shows animated spinner and "progress" text next to Ideation menu item when generation is running
- **Concurrent task warnings**: Toast notifications when starting Ideation while Roadmap is running (and vice versa) to inform users about potential performance impact

### Internationalization
- Added translation keys for progress indicator and concurrent warnings
- Complete translations for both English and French

## Implementation Details

Follows the same architectural pattern as `GitHubPRs` and `TerminalGrid` components:
- Global IPC listener setup (matching commits 596e9513, 05131217)
- Always-mounted with CSS visibility control
- Zustand store state management with project-scoped event filtering

## Files Changed

- `apps/frontend/src/renderer/App.tsx` - Global listener init, always-mounted pattern
- `apps/frontend/src/renderer/components/Sidebar.tsx` - Progress indicator
- `apps/frontend/src/renderer/components/ideation/Ideation.tsx` - Added `isActive` prop
- `apps/frontend/src/renderer/components/ideation/hooks/useIdeation.ts` - Removed local listeners
- `apps/frontend/src/renderer/stores/ideation-store.ts` - Concurrent task detection
- `apps/frontend/src/renderer/stores/roadmap-store.ts` - Concurrent task detection
- `apps/frontend/src/shared/i18n/locales/en/common.json` - EN translations
- `apps/frontend/src/shared/i18n/locales/fr/common.json` - FR translations

## Testing

- ✅ Start Ideation → navigate away → return → verify progress continues
- ✅ Sidebar shows spinner during generation
- ✅ Concurrent task warnings appear when starting both processes
- ✅ All i18n strings use translation keys (no hardcoded text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading spinner with progress indicator displays in sidebar during ideation
  * Warning notifications when Ideation and Roadmap generation run concurrently

* **Improvements**
  * Keyboard shortcuts disabled during active ideation to prevent conflicts
  * Ideation maintains state across view navigation

* **Localization**
  * Added translations for progress indicators and concurrent generation warnings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->