### PR TITLE
fix(python): sanitize environment to prevent PYTHONHOME contamination

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/memory-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/memory-handlers.ts
@@ -25,7 +25,7 @@ import {
 } from '../memory-service';
 import { validateOpenAIApiKey } from '../api-validation-service';
 import { parsePythonCommand } from '../python-detector';
-import { getConfiguredPythonPath } from '../python-env-manager';
+import { getConfiguredPythonPath, pythonEnvManager } from '../python-env-manager';
 import { openTerminalWithCommand } from './claude-code-handlers';
 
 /**
@@ -296,6 +296,9 @@ async function executeOllamaDetector(
     let resolved = false;
     const proc = spawn(pythonExe, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Use sanitized Python environment to prevent PYTHONHOME contamination
+      // Fixes "Could not find platform independent libraries" error on Windows
+      env: pythonEnvManager.getPythonEnv(),
     });
 
     let stdout = '';
@@ -769,6 +772,9 @@ export function registerMemoryHandlers(): void {
           const proc = spawn(pythonExe, args, {
             stdio: ['ignore', 'pipe', 'pipe'],
             timeout: 600000, // 10 minute timeout for large models
+            // Use sanitized Python environment to prevent PYTHONHOME contamination
+            // Fixes "Could not find platform independent libraries" error on Windows
+            env: pythonEnvManager.getPythonEnv(),
           });
 
           let stdout = '';

--- a/apps/frontend/src/main/memory-service.ts
+++ b/apps/frontend/src/main/memory-service.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { app } from 'electron';
 import { findPythonCommand, parsePythonCommand } from './python-detector';
-import { getConfiguredPythonPath } from './python-env-manager';
+import { getConfiguredPythonPath, pythonEnvManager } from './python-env-manager';
 import { getMemoriesDir } from './config-paths';
 import type { MemoryEpisode } from '../shared/types';
 
@@ -134,6 +134,8 @@ async function executeQuery(
     const proc = spawn(pythonExe, fullArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout,
+      // Use sanitized Python environment to prevent PYTHONHOME contamination
+      env: pythonEnvManager.getPythonEnv(),
     });
 
     let stdout = '';
@@ -193,7 +195,8 @@ async function executeSemanticQuery(
   const [pythonExe, baseArgs] = parsePythonCommand(pythonCmd);
 
   // Build environment with embedder configuration
-  const env: Record<string, string | undefined> = { ...process.env };
+  // Start with sanitized Python env to prevent PYTHONHOME contamination
+  const env: Record<string, string | undefined> = { ...pythonEnvManager.getPythonEnv() };
 
   // Set the embedder provider
   env.GRAPHITI_EMBEDDER_PROVIDER = embedderConfig.provider;

--- a/apps/frontend/src/main/python-env-manager.ts
+++ b/apps/frontend/src/main/python-env-manager.ts
@@ -619,23 +619,39 @@ if sys.version_info >= (3, 12):
   /**
    * Get environment variables that should be set when spawning Python processes.
    * This ensures Python finds the bundled packages or venv packages.
+   *
+   * IMPORTANT: This returns a COMPLETE environment (based on process.env) with
+   * problematic Python variables removed. This fixes the "Could not find platform
+   * independent libraries <prefix>" error on Windows when PYTHONHOME is set.
+   *
+   * @see https://github.com/AndyMik90/Auto-Claude/issues/176
    */
   getPythonEnv(): Record<string, string> {
-    const env: Record<string, string> = {
+    // Start with process.env but explicitly remove problematic Python variables
+    // PYTHONHOME causes "Could not find platform independent libraries" when set
+    // to a different Python installation than the one we're spawning
+    const baseEnv: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(process.env)) {
+      // Skip PYTHONHOME - it causes the "platform independent libraries" error
+      // Skip undefined values (TypeScript type guard)
+      if (key !== 'PYTHONHOME' && value !== undefined) {
+        baseEnv[key] = value;
+      }
+    }
+
+    // Apply our Python configuration on top
+    return {
+      ...baseEnv,
       // Don't write bytecode - not needed and avoids permission issues
       PYTHONDONTWRITEBYTECODE: '1',
       // Use UTF-8 encoding
       PYTHONIOENCODING: 'utf-8',
       // Disable user site-packages to avoid conflicts
       PYTHONNOUSERSITE: '1',
+      // Override PYTHONPATH if we have bundled packages
+      ...(this.sitePackagesPath ? { PYTHONPATH: this.sitePackagesPath } : {}),
     };
-
-    // Set PYTHONPATH to our site-packages
-    if (this.sitePackagesPath) {
-      env.PYTHONPATH = this.sitePackagesPath;
-    }
-
-    return env;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #176: Ollama embedding download fails with "Could not find platform independent libraries <prefix>" error on Windows.

## Problem

When spawning Python subprocesses (especially in `executeOllamaDetector()` for Ollama model downloads), the code was not sanitizing the environment. If users had `PYTHONHOME` set in their system environment (common with Anaconda, corporate IT Python installs, or embedded Python like Blender/QGIS), the spawned Python couldn't find its standard library.

## Solution

- Updated `getPythonEnv()` in `python-env-manager.ts` to build a complete environment that explicitly removes `PYTHONHOME`
- Pass this sanitized environment to `spawn()` calls in:
  - `memory-handlers.ts`: `executeOllamaDetector()` (2 locations)
  - `memory-service.ts`: `executeQuery()` and `executeSemanticQuery()`

This follows the same pattern already used in `agent-process.ts` for spawning agent Python processes.

## Testing

- [x] TypeScript compiles without errors
- [x] Code review of changes
- [ ] Manual test on Windows with PYTHONHOME set (cannot test locally - relies on community verification)

## Related

- Fixes ACS-33 (Linear issue)
- May also help with ACS-61 and ACS-72 (related memory issues using same spawn pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Python subprocess environment isolation to ensure reliable execution of Python-dependent features.
* Fixed potential conflicts with Python environment variables that could affect model detection and semantic queries.

## Refactor
* Standardized Python environment initialization across subprocess calls for consistency and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->