### PR TITLE
fix(frontend): detect @lydell/node-pty prebuilts in postinstall

### DIFF
--- a/apps/frontend/scripts/postinstall.cjs
+++ b/apps/frontend/scripts/postinstall.cjs
@@ -93,12 +93,40 @@ function runElectronRebuild() {
  * Check if node-pty is already built
  */
 function isNodePtyBuilt() {
-  const buildDir = path.join(__dirname, '..', 'node_modules', 'node-pty', 'build', 'Release');
-  if (!fs.existsSync(buildDir)) return false;
+  // Check traditional node-pty build location (local node_modules)
+  const localBuildDir = path.join(__dirname, '..', 'node_modules', 'node-pty', 'build', 'Release');
+  if (fs.existsSync(localBuildDir)) {
+    const files = fs.readdirSync(localBuildDir);
+    if (files.some((f) => f.endsWith('.node'))) return true;
+  }
 
-  // Check for the main .node file
-  const files = fs.readdirSync(buildDir);
-  return files.some((f) => f.endsWith('.node'));
+  // Check root node_modules (for npm workspaces)
+  const rootBuildDir = path.join(__dirname, '..', '..', '..', 'node_modules', 'node-pty', 'build', 'Release');
+  if (fs.existsSync(rootBuildDir)) {
+    const files = fs.readdirSync(rootBuildDir);
+    if (files.some((f) => f.endsWith('.node'))) return true;
+  }
+
+  // Check for @lydell/node-pty with platform-specific prebuilts
+  const arch = os.arch();
+  const platform = os.platform();
+  const platformPkg = `@lydell/node-pty-${platform}-${arch}`;
+
+  // Check local node_modules
+  const localLydellDir = path.join(__dirname, '..', 'node_modules', platformPkg);
+  if (fs.existsSync(localLydellDir)) {
+    const files = fs.readdirSync(localLydellDir);
+    if (files.some((f) => f.endsWith('.node'))) return true;
+  }
+
+  // Check root node_modules (for npm workspaces)
+  const rootLydellDir = path.join(__dirname, '..', '..', '..', 'node_modules', platformPkg);
+  if (fs.existsSync(rootLydellDir)) {
+    const files = fs.readdirSync(rootLydellDir);
+    if (files.some((f) => f.endsWith('.node'))) return true;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
The postinstall script was failing on Windows because it only checked for native binaries in the traditional node-pty/build/Release location. This project uses @lydell/node-pty which distributes prebuilt binaries via separate platform-specific packages (e.g., @lydell/node-pty-win32-x64).

Changes:
- Add checks for @lydell/node-pty platform-specific prebuilt packages
- Support npm workspaces by checking both local and root node_modules
- Skip unnecessary electron-rebuild when prebuilts are already available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## CI/Testing Requirements

- [x] All CI checks pass
- [x] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency detection during installation to improve build reliability across different system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->