### PR TITLE
ci(release): add Azure Trusted Signing for Windows builds

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -385,28 +385,64 @@ jobs:
         if: env.AZURE_CLIENT_ID != ''
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
           cd apps/frontend/dist
-          # Find the latest.yml file and update the sha512 hash for signed exe
-          # electron-builder uses base64-encoded SHA512 hashes, not hex
-          $exeFile = Get-ChildItem -Filter "*.exe" | Select-Object -First 1
-          if ($exeFile) {
+
+          # Find the installer exe (electron-builder names it with "Setup" or just the app name)
+          # electron-builder produces one installer exe per build
+          $exeFiles = Get-ChildItem -Filter "*.exe"
+          if ($exeFiles.Count -eq 0) {
+            Write-Host "::error::No .exe files found in dist folder"
+            exit 1
+          }
+
+          Write-Host "Found $($exeFiles.Count) exe file(s): $($exeFiles.Name -join ', ')"
+
+          $ymlFile = "latest.yml"
+          if (-not (Test-Path $ymlFile)) {
+            Write-Host "::error::$ymlFile not found - cannot update checksums"
+            exit 1
+          }
+
+          $content = Get-Content $ymlFile -Raw
+          $originalContent = $content
+
+          # Process each exe file and update its hash in latest.yml
+          foreach ($exeFile in $exeFiles) {
+            Write-Host "Processing $($exeFile.Name)..."
+
             # Compute SHA512 hash and convert to base64 (electron-builder format)
             $bytes = [System.IO.File]::ReadAllBytes($exeFile.FullName)
             $sha512 = [System.Security.Cryptography.SHA512]::Create()
             $hashBytes = $sha512.ComputeHash($bytes)
             $hash = [System.Convert]::ToBase64String($hashBytes)
-            $size = (Get-Item $exeFile.FullName).Length
-            $ymlFile = "latest.yml"
-            if (Test-Path $ymlFile) {
-              $content = Get-Content $ymlFile -Raw
-              # Update sha512 hash (base64 pattern: alphanumeric, +, /, =)
-              $content = $content -replace 'sha512: [A-Za-z0-9+/=]+', "sha512: $hash"
-              # Update size
-              $content = $content -replace 'size: \d+', "size: $size"
-              Set-Content -Path $ymlFile -Value $content -NoNewline
-              Write-Host "Updated $ymlFile with new base64 hash: $hash and size: $size"
-            }
+            $size = $exeFile.Length
+
+            Write-Host "  Hash: $hash"
+            Write-Host "  Size: $size"
           }
+
+          # For electron-builder, latest.yml has a single file entry for the installer
+          # Update the sha512 and size for the primary exe (first one, typically the installer)
+          $primaryExe = $exeFiles | Select-Object -First 1
+          $bytes = [System.IO.File]::ReadAllBytes($primaryExe.FullName)
+          $sha512 = [System.Security.Cryptography.SHA512]::Create()
+          $hashBytes = $sha512.ComputeHash($bytes)
+          $hash = [System.Convert]::ToBase64String($hashBytes)
+          $size = $primaryExe.Length
+
+          # Update sha512 hash (base64 pattern: alphanumeric, +, /, =)
+          $content = $content -replace 'sha512: [A-Za-z0-9+/=]+', "sha512: $hash"
+          # Update size
+          $content = $content -replace 'size: \d+', "size: $size"
+
+          if ($content -eq $originalContent) {
+            Write-Host "::error::Checksum replacement failed - content unchanged. Check if latest.yml format has changed."
+            exit 1
+          }
+
+          Set-Content -Path $ymlFile -Value $content -NoNewline
+          Write-Host "✅ Updated $ymlFile with new base64 hash and size for $($primaryExe.Name)"
 
       - name: Skip signing notice
         if: env.AZURE_CLIENT_ID == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,28 +321,64 @@ jobs:
         if: env.AZURE_CLIENT_ID != ''
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
           cd apps/frontend/dist
-          # Find the latest.yml file and update the sha512 hash for signed exe
-          # electron-builder uses base64-encoded SHA512 hashes, not hex
-          $exeFile = Get-ChildItem -Filter "*.exe" | Select-Object -First 1
-          if ($exeFile) {
+
+          # Find the installer exe (electron-builder names it with "Setup" or just the app name)
+          # electron-builder produces one installer exe per build
+          $exeFiles = Get-ChildItem -Filter "*.exe"
+          if ($exeFiles.Count -eq 0) {
+            Write-Host "::error::No .exe files found in dist folder"
+            exit 1
+          }
+
+          Write-Host "Found $($exeFiles.Count) exe file(s): $($exeFiles.Name -join ', ')"
+
+          $ymlFile = "latest.yml"
+          if (-not (Test-Path $ymlFile)) {
+            Write-Host "::error::$ymlFile not found - cannot update checksums"
+            exit 1
+          }
+
+          $content = Get-Content $ymlFile -Raw
+          $originalContent = $content
+
+          # Process each exe file and update its hash in latest.yml
+          foreach ($exeFile in $exeFiles) {
+            Write-Host "Processing $($exeFile.Name)..."
+
             # Compute SHA512 hash and convert to base64 (electron-builder format)
             $bytes = [System.IO.File]::ReadAllBytes($exeFile.FullName)
             $sha512 = [System.Security.Cryptography.SHA512]::Create()
             $hashBytes = $sha512.ComputeHash($bytes)
             $hash = [System.Convert]::ToBase64String($hashBytes)
-            $size = (Get-Item $exeFile.FullName).Length
-            $ymlFile = "latest.yml"
-            if (Test-Path $ymlFile) {
-              $content = Get-Content $ymlFile -Raw
-              # Update sha512 hash (base64 pattern: alphanumeric, +, /, =)
-              $content = $content -replace 'sha512: [A-Za-z0-9+/=]+', "sha512: $hash"
-              # Update size
-              $content = $content -replace 'size: \d+', "size: $size"
-              Set-Content -Path $ymlFile -Value $content -NoNewline
-              Write-Host "Updated $ymlFile with new base64 hash: $hash and size: $size"
-            }
+            $size = $exeFile.Length
+
+            Write-Host "  Hash: $hash"
+            Write-Host "  Size: $size"
           }
+
+          # For electron-builder, latest.yml has a single file entry for the installer
+          # Update the sha512 and size for the primary exe (first one, typically the installer)
+          $primaryExe = $exeFiles | Select-Object -First 1
+          $bytes = [System.IO.File]::ReadAllBytes($primaryExe.FullName)
+          $sha512 = [System.Security.Cryptography.SHA512]::Create()
+          $hashBytes = $sha512.ComputeHash($bytes)
+          $hash = [System.Convert]::ToBase64String($hashBytes)
+          $size = $primaryExe.Length
+
+          # Update sha512 hash (base64 pattern: alphanumeric, +, /, =)
+          $content = $content -replace 'sha512: [A-Za-z0-9+/=]+', "sha512: $hash"
+          # Update size
+          $content = $content -replace 'size: \d+', "size: $size"
+
+          if ($content -eq $originalContent) {
+            Write-Host "::error::Checksum replacement failed - content unchanged. Check if latest.yml format has changed."
+            exit 1
+          }
+
+          Set-Content -Path $ymlFile -Value $content -NoNewline
+          Write-Host "✅ Updated $ymlFile with new base64 hash and size for $($primaryExe.Name)"
 
       - name: Skip signing notice
         if: env.AZURE_CLIENT_ID == ''


### PR DESCRIPTION
## Summary

Integrate Azure Trusted Signing to sign Windows executables during release workflows. This removes SmartScreen warnings ("Windows protected your PC") for users downloading Auto-Claude on Windows.

## Changes

### Workflow Updates (`release.yml` and `beta-release.yml`)

- **Added OIDC authentication with Azure** - Uses `azure/login@v2` with workload identity federation (no client secrets to manage)
- **Integrated `azure/trusted-signing-action@v0.5.1`** - Signs all `.exe` files after packaging
- **Uses North Europe endpoint** (`neu.codesigning.azure.net`)
- **Conditional execution** - Signing step only runs if Azure credentials are configured

### Key Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Added Azure login + signing steps, permissions for OIDC |
| `.github/workflows/beta-release.yml` | Added Azure login + signing steps, permissions for OIDC |

## Required GitHub Secrets

To enable signing, the following secrets must be configured:

| Secret | Description |
|--------|-------------|
| `AZURE_TENANT_ID` | Azure AD tenant ID |
| `AZURE_CLIENT_ID` | App registration client ID |
| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
| `AZURE_SIGNING_ACCOUNT` | Trusted Signing account name |
| `AZURE_CERTIFICATE_PROFILE` | Certificate profile name |

## Azure Setup Required

1. App Registration with federated credential for GitHub Actions
2. Trusted Signing account with validated identity
3. Certificate profile linked to the identity
4. IAM role assignment: "Trusted Signing Certificate Profile Signer"

## Testing

- [ ] Dry-run release workflow to verify signing step
- [ ] Verify signed `.exe` shows publisher name (not "Unknown publisher")

## Notes

- Signing is skipped gracefully if Azure credentials are not configured
- Uses OIDC (workload identity federation) - no client secrets to rotate
- Disabled electron-builder's built-in signing (`CSC_IDENTITY_AUTO_DISCOVERY: false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an optional Azure-based Windows code-signing path for signed installers when configured.
  * Signing, verification, and checksum regeneration occur post-signing to ensure release artifacts are updated.
  * Workflow now gracefully skips signing with a clear notice if signing is not configured.
  * Preserved existing packaging behavior and retained error-monitoring integration across builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->