### PR TITLE
fix(ACS-181): enable auto-switch for OAuth-only profiles

### DIFF
--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -56,9 +56,16 @@ export async function createProfileDirectory(profileName: string): Promise<strin
 
 /**
  * Check if a profile has valid authentication
- * (checks if the config directory has credential files or OAuth account info)
+ * (checks for OAuth token or config directory credential files)
  */
 export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
+  // Check for direct OAuth token first (OAuth-only profiles without configDir)
+  // This enables auto-switch to work with profiles that only have oauthToken set
+  if (hasValidToken(profile)) {
+    return true;
+  }
+
+  // Check for configDir-based credentials (legacy or CLI-authenticated profiles)
   const configDir = profile.configDir;
   if (!configDir || !existsSync(configDir)) {
     return false;


### PR DESCRIPTION
## Summary

- Add OAuth token check at the start of `isProfileAuthenticated()` so OAuth-only profiles are recognized as authenticated
- Fixes proactive auto-switch not triggering when alternative profiles only have `oauthToken` set (no `configDir`)
- Uses existing `hasValidToken()` function which also validates token expiry

## Problem

`isProfileAuthenticated()` in `profile-utils.ts` immediately returned `false` if `configDir` was missing, causing OAuth-only profiles to receive a -500 penalty in the profile scorer and never be selected for auto-switch.

## Solution

Check for valid OAuth token at the start of `isProfileAuthenticated()` before checking `configDir`-based credentials:

```typescript
export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
  // Check for direct OAuth token first (OAuth-only profiles without configDir)
  if (hasValidToken(profile)) {
    return true;
  }
  // ... existing configDir checks
}
```

## Test plan

- [ ] Build the app and verify it compiles
- [ ] Set up 2+ profiles with OAuth tokens
- [ ] Test manual account switching mid-task
- [ ] Test auto-switch triggers when usage threshold is reached
- [ ] Verify rate limit recovery switches to OAuth-only profile

## Linked Issues

- Fixes #850
- Linear: ACS-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)