### PR TITLE
fix(worktree): filter worktrees by branch pattern and handle orphaned state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ lerna-debug.log*
 .auto-claude-status
 .claude_settings.json
 .update-metadata.json
+tmpclaude-*
 
 # ===========================
 # Python (apps/backend)

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -652,7 +652,10 @@ class WorktreeManager:
         result = self._run_git(merge_args)
 
         if result.returncode != 0:
-            print("Merge conflict! Aborting merge...")
+            error_detail = (
+                result.stderr.strip() or result.stdout.strip() or "Unknown error"
+            )
+            print(f"Merge failed: {error_detail}")
             self._run_git(["merge", "--abort"])
             return False
 

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -31,12 +31,6 @@ from debug import debug_warning
 
 T = TypeVar("T")
 
-# Base/default branch names that should be filtered out when listing worktrees.
-# Used to detect orphaned worktrees after GitHub merge operations.
-# Comparison should be case-insensitive (use .lower()).
-# NOTE: Keep in sync with BASE_BRANCHES in apps/frontend/src/shared/constants/git.ts
-BASE_BRANCHES: frozenset[str] = frozenset({"main", "master", "develop", "head"})
-
 
 def _is_retryable_network_error(stderr: str) -> bool:
     """Check if an error is a retryable network/connection issue."""
@@ -697,14 +691,17 @@ class WorktreeManager:
         """List all spec worktrees (includes legacy .worktrees/ location)."""
         worktrees = []
         seen_specs = set()
+        # Skip worktrees on base branches (orphaned after GitHub merge)
+        # But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
+        # Use case-insensitive comparison for robustness
+        base_branches = {"main", "master", "develop", "head"}
 
         # Check new location first
         if self.worktrees_dir.exists():
             for item in self.worktrees_dir.iterdir():
                 if item.is_dir():
                     info = self.get_worktree_info(item.name)
-                    # Skip worktrees on base branches (orphaned after GitHub merge)
-                    if info and info.branch.lower() not in BASE_BRANCHES:
+                    if info and info.branch.lower() not in base_branches:
                         worktrees.append(info)
                         seen_specs.add(item.name)
 
@@ -714,7 +711,7 @@ class WorktreeManager:
             for item in legacy_dir.iterdir():
                 if item.is_dir() and item.name not in seen_specs:
                     info = self.get_worktree_info(item.name)
-                    if info and info.branch.lower() not in BASE_BRANCHES:
+                    if info and info.branch.lower() not in base_branches:
                         worktrees.append(info)
 
         return worktrees

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -719,7 +719,10 @@ class WorktreeManager:
             for item in self.worktrees_dir.iterdir():
                 if item.is_dir():
                     info = self.get_worktree_info(item.name)
-                    if info:
+                    # Skip if worktree is on a base branch (orphaned after GitHub merge)
+                    # But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
+                    base_branches = {"main", "master", "develop", "HEAD"}
+                    if info and info.branch not in base_branches:
                         worktrees.append(info)
                         seen_specs.add(item.name)
 
@@ -729,7 +732,9 @@ class WorktreeManager:
             for item in legacy_dir.iterdir():
                 if item.is_dir() and item.name not in seen_specs:
                     info = self.get_worktree_info(item.name)
-                    if info:
+                    # Skip if worktree is on a base branch
+                    base_branches = {"main", "master", "develop", "HEAD"}
+                    if info and info.branch not in base_branches:
                         worktrees.append(info)
 
         return worktrees

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -713,15 +713,15 @@ class WorktreeManager:
         """List all spec worktrees (includes legacy .worktrees/ location)."""
         worktrees = []
         seen_specs = set()
+        # Skip worktrees on base branches (orphaned after GitHub merge)
+        # But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
+        base_branches = {"main", "master", "develop", "HEAD"}
 
         # Check new location first
         if self.worktrees_dir.exists():
             for item in self.worktrees_dir.iterdir():
                 if item.is_dir():
                     info = self.get_worktree_info(item.name)
-                    # Skip if worktree is on a base branch (orphaned after GitHub merge)
-                    # But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
-                    base_branches = {"main", "master", "develop", "HEAD"}
                     if info and info.branch not in base_branches:
                         worktrees.append(info)
                         seen_specs.add(item.name)
@@ -732,8 +732,6 @@ class WorktreeManager:
             for item in legacy_dir.iterdir():
                 if item.is_dir() and item.name not in seen_specs:
                     info = self.get_worktree_info(item.name)
-                    # Skip if worktree is on a base branch
-                    base_branches = {"main", "master", "develop", "HEAD"}
                     if info and info.branch not in base_branches:
                         worktrees.append(info)
 

--- a/apps/frontend/src/main/__tests__/insights-config.test.ts
+++ b/apps/frontend/src/main/__tests__/insights-config.test.ts
@@ -59,9 +59,8 @@ describe('InsightsConfig', () => {
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
     expect(env.ANTHROPIC_BASE_URL).toBe('https://api.z.ai');
     expect(env.ANTHROPIC_AUTH_TOKEN).toBe('key');
-    expect(env.PYTHONPATH).toBe(
-      [path.resolve('/site-packages'), path.resolve('/backend')].join(path.delimiter)
-    );
+    // path.resolve() normalizes paths to platform-specific format
+    expect(env.PYTHONPATH).toBe([path.resolve('/site-packages'), path.resolve('/backend')].join(path.delimiter));
   });
 
   it('should clear ANTHROPIC env vars in OAuth mode when no API profile is set', async () => {
@@ -86,6 +85,7 @@ describe('InsightsConfig', () => {
 
     const env = await config.getProcessEnv();
 
+    // path.resolve() normalizes paths to platform-specific format
     expect(env.PYTHONPATH).toBe(path.resolve('/backend'));
   });
 
@@ -96,6 +96,7 @@ describe('InsightsConfig', () => {
 
     const env = await config.getProcessEnv();
 
+    // path.resolve() normalizes paths to platform-specific format
     expect(env.PYTHONPATH).toBe(path.resolve('/site-packages'));
   });
 });

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron';
-import { IPC_CHANNELS, AUTO_BUILD_PATHS, getSpecsDir } from '../../../shared/constants';
+import { IPC_CHANNELS, AUTO_BUILD_PATHS, getSpecsDir, BASE_BRANCHES } from '../../../shared/constants';
 import type { IPCResult, TaskStartOptions, TaskStatus, ImageAttachment } from '../../../shared/types';
 import path from 'path';
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, rmSync } from 'fs';
@@ -41,8 +41,7 @@ function getWorktreeBranch(worktreePath: string): string | null {
     // Skip if on a base branch (orphaned after GitHub merge)
     // Allow any feature branch pattern (auto-claude/*, feature/*, etc.)
     // Use case-insensitive comparison for robustness
-    const baseBranches = ['main', 'master', 'develop', 'head'];
-    if (baseBranches.includes(branch.toLowerCase())) {
+    if (BASE_BRANCHES.includes(branch.toLowerCase() as typeof BASE_BRANCHES[number])) {
       return null;
     }
     return branch;

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -784,6 +784,10 @@ export function registerTaskExecutionHandlers(
       // OR skipCleanup is requested (user wants to mark done without cleanup)
       // OR the worktree is in an invalid state (orphaned after GitHub PR merge)
       if (status === 'done') {
+        // Stop file watcher BEFORE any cleanup operations to release file handles
+        // This prevents file-locking issues on Windows where chokidar holds handles open
+        fileWatcher.unwatch(taskId);
+
         // If skipCleanup is requested, skip all worktree operations
         if (options?.skipCleanup) {
           console.warn(`[TASK_UPDATE_STATUS] Skipping worktree cleanup for task ${taskId} (user requested)`);

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -123,7 +123,7 @@ async function removeWorktreeWithRetry(
 }
 
 /**
- * Prune stale worktree references (best-effort, ignores errors).
+ * Prune stale worktree references (best-effort, logs errors for debugging).
  */
 function pruneWorktrees(projectPath: string): void {
   try {
@@ -132,8 +132,8 @@ function pruneWorktrees(projectPath: string): void {
       encoding: 'utf-8',
       timeout: 30000
     });
-  } catch {
-    // Ignore prune errors
+  } catch (e) {
+    console.debug('[pruneWorktrees] Prune failed (non-blocking):', e);
   }
 }
 

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -2,7 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron';
 import { IPC_CHANNELS, AUTO_BUILD_PATHS, getSpecsDir } from '../../../shared/constants';
 import type { IPCResult, TaskStartOptions, TaskStatus, ImageAttachment } from '../../../shared/types';
 import path from 'path';
-import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, rmSync } from 'fs';
 import { spawnSync, execFileSync } from 'child_process';
 import { getToolPath } from '../../cli-tool-manager';
 import { AgentManager } from '../../agent';
@@ -615,8 +615,7 @@ export function registerTaskExecutionHandlers(
               } catch {
                 // If git worktree remove fails, the directory might not be a valid worktree
                 // Just remove the directory manually
-                const fs = require('fs');
-                fs.rmSync(worktreePath, { recursive: true, force: true });
+                rmSync(worktreePath, { recursive: true, force: true });
                 console.warn(`[TASK_UPDATE_STATUS] Orphaned worktree directory deleted: ${worktreePath}`);
               }
 
@@ -685,8 +684,7 @@ export function registerTaskExecutionHandlers(
                 if (errorMessage.includes('not a working tree') || errorMessage.includes('is not a valid working tree')) {
                   console.warn(`[TASK_UPDATE_STATUS] Directory exists but isn't a git worktree - deleting directly`);
                   try {
-                    const fs = require('fs');
-                    fs.rmSync(worktreePath, { recursive: true, force: true });
+                    rmSync(worktreePath, { recursive: true, force: true });
                     removed = true;
                     console.warn(`[TASK_UPDATE_STATUS] Directory deleted: ${worktreePath}`);
                     // Prune any stale worktree references

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -815,9 +815,11 @@ export function registerTaskExecutionHandlers(
             const expectedBranch = `auto-claude/${task.specId}`;
             const cleanupResult = cleanupOrphanedWorktree(project.path, worktreePath, expectedBranch);
             if (!cleanupResult.success) {
-              // Orphaned cleanup failed - notify user but don't block marking as done
+              // Orphaned cleanup failed - return error so UI can show "Skip Cleanup" option
+              // This prevents silent accumulation of orphaned directories that can cause
+              // "already exists" errors on future task creations
               console.warn(`[TASK_UPDATE_STATUS] Orphaned worktree cleanup failed: ${cleanupResult.error}`);
-              // Continue to mark as done - orphaned worktree cleanup failure is non-blocking
+              return cleanupResult;
             }
           } else if (branchResult.valid && options?.forceCleanup) {
             // Valid worktree exists and user confirmed cleanup

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -897,6 +897,7 @@ export function registerTaskExecutionHandlers(
         if (status !== 'in_progress' && agentManager.isRunning(taskId)) {
           console.warn('[TASK_UPDATE_STATUS] Stopping task due to status change away from in_progress:', taskId);
           agentManager.killTask(taskId);
+          fileWatcher.unwatch(taskId);
         }
 
         // Auto-start task when status changes to 'in_progress' and no process is running

--- a/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain, BrowserWindow, shell, app } from 'electron';
-import { IPC_CHANNELS, AUTO_BUILD_PATHS, DEFAULT_APP_SETTINGS, DEFAULT_FEATURE_MODELS, DEFAULT_FEATURE_THINKING, MODEL_ID_MAP, THINKING_BUDGET_MAP, getSpecsDir } from '../../../shared/constants';
+import { IPC_CHANNELS, AUTO_BUILD_PATHS, DEFAULT_APP_SETTINGS, DEFAULT_FEATURE_MODELS, DEFAULT_FEATURE_THINKING, MODEL_ID_MAP, THINKING_BUDGET_MAP, getSpecsDir, BASE_BRANCHES } from '../../../shared/constants';
 import type { IPCResult, WorktreeStatus, WorktreeDiff, WorktreeDiffFile, WorktreeMergeResult, WorktreeDiscardResult, WorktreeListResult, WorktreeListItem, WorktreeCreatePROptions, WorktreeCreatePRResult, SupportedIDE, SupportedTerminal, AppSettings } from '../../../shared/types';
 import path from 'path';
 import { existsSync, readdirSync, statSync, readFileSync } from 'fs';
@@ -2681,8 +2681,8 @@ export function registerWorktreeHandlers(
             // Skip if HEAD is detached or pointing to a main/base branch
             // (this can happen if worktree is orphaned after GitHub merge)
             // But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
-            const baseBranches = ['main', 'master', 'develop', 'HEAD'];
-            if (baseBranches.includes(branch)) {
+            // Use case-insensitive comparison for robustness
+            if (BASE_BRANCHES.includes(branch.toLowerCase() as typeof BASE_BRANCHES[number])) {
               console.warn(`[TASK_LIST_WORKTREES] Skipping worktree ${entry} - on base branch: ${branch}`);
               return; // Skip - likely orphaned or misconfigured
             }

--- a/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
@@ -2678,6 +2678,15 @@ export function registerWorktreeHandlers(
               encoding: 'utf-8'
             }).trim();
 
+            // Skip if HEAD is detached or pointing to a main/base branch
+            // (this can happen if worktree is orphaned after GitHub merge)
+            // But allow any feature branch pattern (auto-claude/*, feature/*, etc.)
+            const baseBranches = ['main', 'master', 'develop', 'HEAD'];
+            if (baseBranches.includes(branch)) {
+              console.warn(`[TASK_LIST_WORKTREES] Skipping worktree ${entry} - on base branch: ${branch}`);
+              return; // Skip - likely orphaned or misconfigured
+            }
+
             // Get base branch using proper fallback chain:
             // 1. Task metadata baseBranch, 2. Project settings mainBranch, 3. main/master detection
             // Note: We do NOT use current HEAD as that may be a feature branch

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -42,8 +42,8 @@ export interface TaskAPI {
   updateTaskStatus: (
     taskId: string,
     status: TaskStatus,
-    options?: { forceCleanup?: boolean }
-  ) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }>;
+    options?: { forceCleanup?: boolean; skipCleanup?: boolean }
+  ) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string; canSkipCleanup?: boolean }>;
   recoverStuckTask: (
     taskId: string,
     options?: import('../../shared/types').TaskRecoveryOptions
@@ -122,8 +122,8 @@ export const createTaskAPI = (): TaskAPI => ({
   updateTaskStatus: (
     taskId: string,
     status: TaskStatus,
-    options?: { forceCleanup?: boolean }
-  ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }> =>
+    options?: { forceCleanup?: boolean; skipCleanup?: boolean }
+  ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string; canSkipCleanup?: boolean }> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_UPDATE_STATUS, taskId, status, options),
 
   recoverStuckTask: (

--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -538,7 +538,7 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
   const handleWorktreeSkipCleanup = async () => {
     if (!worktreeCleanupDialog.taskId) return;
 
-    setWorktreeCleanupDialog(prev => ({ ...prev, isProcessing: true, error: undefined }));
+    setWorktreeCleanupDialog(prev => ({ ...prev, isProcessing: true, error: undefined, canSkipCleanup: false }));
 
     const result = await skipCleanupCompleteTask(worktreeCleanupDialog.taskId);
 

--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -545,7 +545,8 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
       setWorktreeCleanupDialog(prev => ({
         ...prev,
         isProcessing: false,
-        error: result.error || t('dialogs:worktreeCleanup.errorDescription')
+        error: result.error || t('dialogs:worktreeCleanup.errorDescription'),
+        canSkipCleanup: result.canSkipCleanup || false
       }));
     }
   };

--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -59,27 +59,6 @@ interface DroppableColumnProps {
   onToggleArchived?: () => void;
 }
 
-// Worktree cleanup dialog state - defined at module scope for referential stability
-type WorktreeCleanupDialogState = {
-  open: boolean;
-  taskId: string | null;
-  taskTitle: string;
-  worktreePath?: string;
-  isProcessing: boolean;
-  error?: string;
-  canSkipCleanup?: boolean;
-};
-
-const INITIAL_WORKTREE_DIALOG_STATE: WorktreeCleanupDialogState = {
-  open: false,
-  taskId: null,
-  taskTitle: '',
-  worktreePath: undefined,
-  isProcessing: false,
-  error: undefined,
-  canSkipCleanup: false
-};
-
 /**
  * Compare two tasks arrays for meaningful changes.
  * Returns true if tasks are equivalent (should skip re-render).
@@ -368,6 +347,27 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
   const [overColumnId, setOverColumnId] = useState<string | null>(null);
   const { showArchived, toggleShowArchived } = useViewState();
 
+  // Worktree cleanup dialog state
+  type WorktreeCleanupDialogState = {
+    open: boolean;
+    taskId: string | null;
+    taskTitle: string;
+    worktreePath?: string;
+    isProcessing: boolean;
+    error?: string;
+    canSkipCleanup?: boolean;
+  };
+
+  const INITIAL_WORKTREE_DIALOG_STATE: WorktreeCleanupDialogState = {
+    open: false,
+    taskId: null,
+    taskTitle: '',
+    worktreePath: undefined,
+    isProcessing: false,
+    error: undefined,
+    canSkipCleanup: false
+  };
+
   const [worktreeCleanupDialog, setWorktreeCleanupDialog] = useState<WorktreeCleanupDialogState>(INITIAL_WORKTREE_DIALOG_STATE);
 
   // Calculate archived count for Done column button
@@ -545,8 +545,7 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
       setWorktreeCleanupDialog(prev => ({
         ...prev,
         isProcessing: false,
-        error: result.error || t('dialogs:worktreeCleanup.errorDescription'),
-        canSkipCleanup: result.canSkipCleanup || false
+        error: result.error || t('dialogs:worktreeCleanup.errorDescription')
       }));
     }
   };

--- a/apps/frontend/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/apps/frontend/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -17,8 +17,10 @@ interface WorktreeCleanupDialogProps {
   worktreePath?: string;
   isProcessing: boolean;
   error?: string;
+  canSkipCleanup?: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
+  onSkipCleanup?: () => void;
 }
 
 /**
@@ -30,8 +32,10 @@ export function WorktreeCleanupDialog({
   worktreePath,
   isProcessing,
   error,
+  canSkipCleanup,
   onOpenChange,
-  onConfirm
+  onConfirm,
+  onSkipCleanup
 }: WorktreeCleanupDialogProps) {
   const { t } = useTranslation(['dialogs', 'common']);
 
@@ -80,6 +84,19 @@ export function WorktreeCleanupDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isProcessing}>{t('common:buttons.cancel')}</AlertDialogCancel>
+          {error && canSkipCleanup && onSkipCleanup && (
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                onSkipCleanup();
+              }}
+              disabled={isProcessing}
+              className="bg-muted text-muted-foreground hover:bg-muted/80"
+            >
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+              {t('dialogs:worktreeCleanup.skipCleanup', 'Mark Done (Keep Worktree)')}
+            </AlertDialogAction>
+          )}
           <AlertDialogAction
             onClick={(e) => {
               e.preventDefault();

--- a/apps/frontend/src/shared/constants/git.ts
+++ b/apps/frontend/src/shared/constants/git.ts
@@ -1,0 +1,15 @@
+/**
+ * Git-related constants
+ *
+ * NOTE: These constants are also defined in apps/backend/core/worktree.py
+ * If you modify BASE_BRANCHES here, ensure the Python version stays in sync.
+ */
+
+/**
+ * Base/default branch names that should be filtered out when listing worktrees.
+ * Used to detect orphaned worktrees after GitHub merge operations.
+ * Comparison should be case-insensitive (use .toLowerCase()).
+ */
+export const BASE_BRANCHES = ['main', 'master', 'develop', 'head'] as const;
+
+export type BaseBranch = (typeof BASE_BRANCHES)[number];

--- a/apps/frontend/src/shared/constants/index.ts
+++ b/apps/frontend/src/shared/constants/index.ts
@@ -35,3 +35,6 @@ export * from './api-profiles';
 
 // Configuration and paths
 export * from './config';
+
+// Git-related constants
+export * from './git';

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -160,7 +160,7 @@ export interface ElectronAPI {
   startTask: (taskId: string, options?: TaskStartOptions) => void;
   stopTask: (taskId: string) => void;
   submitReview: (taskId: string, approved: boolean, feedback?: string, images?: ImageAttachment[]) => Promise<IPCResult>;
-  updateTaskStatus: (taskId: string, status: TaskStatus, options?: { forceCleanup?: boolean }) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }>;
+  updateTaskStatus: (taskId: string, status: TaskStatus, options?: { forceCleanup?: boolean; skipCleanup?: boolean }) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string; canSkipCleanup?: boolean }>;
   recoverStuckTask: (taskId: string, options?: TaskRecoveryOptions) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
 

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -438,6 +438,16 @@ export interface WorktreeCreatePRResult {
 }
 
 /**
+ * Result of worktree cleanup operations (removing worktree directory and branch)
+ */
+export interface WorktreeCleanupResult {
+  success: boolean;
+  canSkipCleanup?: boolean;
+  worktreePath?: string;
+  error?: string;
+}
+
+/**
  * Information about a single spec worktree
  * Per-spec architecture: Each spec has its own worktree at .worktrees/{spec-name}/
  */

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -723,10 +723,14 @@ class TestCrossLanguageConstantValidation:
         apps/backend/core/worktree.py and apps/frontend/src/shared/constants/git.ts
         is maintained.
         """
-        # Path to the TypeScript constant file
-        ts_file = Path(__file__).parent.parent / "apps" / "frontend" / "src" / "shared" / "constants" / "git.ts"
+        # Navigate from tests/ to repo root, then to frontend constants
+        repo_root = Path(__file__).parent.parent
+        ts_file = repo_root / "apps" / "frontend" / "src" / "shared" / "constants" / "git.ts"
 
-        assert ts_file.exists(), f"TypeScript constants file not found: {ts_file}"
+        assert ts_file.exists(), (
+            f"TypeScript constants file not found: {ts_file}\n"
+            f"Expected path relative to repo root: apps/frontend/src/shared/constants/git.ts"
+        )
 
         # Read and parse TypeScript file
         ts_content = ts_file.read_text()


### PR DESCRIPTION
## Summary

- Filter worktree listings to only include feature branches (not main/master/develop)
- Auto-cleanup orphaned worktrees when marking task as done
- Handle "not a working tree" error by deleting directory directly
- Add retry logic with better error messages for Windows file locks
- Add "Skip Cleanup" option when cleanup fails (marks done without deleting worktree)

## Problem

When a PR is merged via the GitHub web UI:
1. The local worktree may still exist but be in an invalid state
2. The worktree list was showing the main branch worktree when no feature worktrees existed
3. Marking a task as done could fail if files were locked by the app itself

## Solution

1. **Worktree filtering**: Only show worktrees on feature branches (not main/master/develop/HEAD)
2. **Orphaned worktree handling**: Auto-detect and cleanup orphaned worktrees
3. **Skip cleanup option**: When cleanup fails, users can mark done anyway and delete the worktree manually later

## Test plan

- [ ] Start a task, stop it mid-execution, try to mark as done
- [ ] Merge a PR via GitHub web UI, then mark the task as done
- [ ] Verify worktree list shows empty when no feature worktrees exist
- [ ] Verify "Skip Cleanup" button appears when cleanup fails

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Mark Done (Keep Worktree)" skip-cleanup flow added to UI and APIs (new skipCleanup option and canSkipCleanup indicator).

* **Bug Fixes**
  * Base branches (main/master/develop/head) are excluded from worktree listings; worktree cleanup made more robust (retries, pruning, clearer failure handling).

* **Tests**
  * Cross-language constant sync test added and platform-aware path/quoting test fixes.

* **Chores**
  * .gitignore updated to ignore temporary Claude-generated files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->