### PR TITLE
fix(ci): fix semver comparison for release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,13 @@ on:
     paths:
       - 'apps/frontend/package.json'
       - 'package.json'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force release even if version check fails (use with caution)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   check-and-tag:
@@ -54,16 +61,20 @@ jobs:
         run: |
           PACKAGE_VERSION="${{ steps.package.outputs.version }}"
           LATEST_VERSION="${{ steps.latest_tag.outputs.version }}"
+          FORCE="${{ github.event.inputs.force }}"
 
           echo "Comparing: package=$PACKAGE_VERSION vs latest_tag=$LATEST_VERSION"
 
-          # Use sort -V for version comparison
-          HIGHER=$(printf '%s\n%s' "$PACKAGE_VERSION" "$LATEST_VERSION" | sort -V | tail -n1)
-
-          if [ "$HIGHER" = "$PACKAGE_VERSION" ] && [ "$PACKAGE_VERSION" != "$LATEST_VERSION" ]; then
+          # Use npx semver for proper semantic version comparison
+          # This correctly handles pre-release versions (2.7.3 > 2.7.3-beta.1)
+          if npx -y semver "$PACKAGE_VERSION" -r ">$LATEST_VERSION" > /dev/null 2>&1; then
             echo "should_release=true" >> $GITHUB_OUTPUT
             echo "new_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
             echo "✅ New release needed: v$PACKAGE_VERSION"
+          elif [ "$FORCE" = "true" ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "new_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+            echo "⚠️ Force release enabled: v$PACKAGE_VERSION"
           else
             echo "should_release=false" >> $GITHUB_OUTPUT
             echo "⏭️ No release needed (package version not newer than latest tag)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,7 +442,7 @@
 - fix: Solve ladybug problem on running npm install all on windows (#576) by @Alex in effaa681
 - fix(merge): handle Windows CRLF line endings in regex fallback by @AndyMik90 in 04de8c78
 - ci(release): add CHANGELOG.md validation and fix release workflow by @AndyMik90 in 6d4231ed
-- # 🔥 hotfix(electron): restore app functionality on Windows broken by GPU cache errors (#569) by @sniggl in dedd0757
+- 🔥 hotfix(electron): restore app functionality on Windows broken by GPU cache errors (#569) by @sniggl in dedd0757
 - fix(ci): cache pip wheels to speed up Intel Mac builds by @AndyMik90 in 90dddc28
 - feat(terminal): respect preferred terminal setting for Windows PTY shell by @AndyMik90 in 90a20320
 - fix(ci): add Python setup to beta-release and fix PR status gate checks (#565) by @Andy in c2148bb9


### PR DESCRIPTION
## Summary

- Fix `prepare-release.yml` to use `npx semver` for proper semantic version comparison
  - `sort -V` incorrectly ranked `2.7.3-beta.1` > `2.7.3`, blocking the v2.7.3 release
  - Now correctly recognizes that stable versions are newer than pre-release versions
- Add `workflow_dispatch` trigger with force option for manual releases
- Fix CHANGELOG.md formatting (remove `#` that caused header rendering issue)

## Why This Was Needed

The v2.7.3 release was blocked because `sort -V` doesn't follow semver rules:
```bash
$ printf '%s\n%s' "2.7.3" "2.7.3-beta.1" | sort -V | tail -n1
2.7.3-beta.1  # WRONG - should be 2.7.3
```

In semver, `2.7.3` (stable) > `2.7.3-beta.1` (pre-release).

## Test Plan

- [ ] Merge this PR to main
- [ ] Manually trigger "Prepare Release" workflow from Actions tab
- [ ] Verify v2.7.3 tag is created and release workflow starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)