### PR TITLE
fix(terminal): add collision detection for terminal drag and drop reordering

### DIFF
--- a/apps/frontend/src/renderer/components/TerminalGrid.tsx
+++ b/apps/frontend/src/renderer/components/TerminalGrid.tsx
@@ -293,17 +293,22 @@ export function TerminalGrid({ projectPath, onNewTaskClick, isActive = false }: 
 
     // Handle file drop on terminal
     const overId = over.id.toString();
-    if (overId.startsWith('terminal-')) {
-      const terminalId = overId.replace('terminal-', '');
+    let terminalId: string | null = null;
 
-      if (activeData?.path) {
-        // Quote the path if it contains spaces
-        const quotedPath = activeData.path.includes(' ') ? `"${activeData.path}"` : activeData.path;
-        // Insert the file path into the terminal with a trailing space
-        window.electronAPI.sendTerminalInput(terminalId, quotedPath + ' ');
-      }
+    if (overId.startsWith('terminal-')) {
+      terminalId = overId.replace('terminal-', '');
+    } else if (terminals.some(t => t.id === overId)) {
+      // closestCenter might return the sortable ID instead of droppable ID
+      terminalId = overId;
     }
-  }, [reorderTerminals]);
+
+    if (terminalId && activeData?.path) {
+      // Quote the path if it contains spaces
+      const quotedPath = activeData.path.includes(' ') ? `"${activeData.path}"` : activeData.path;
+      // Insert the file path into the terminal with a trailing space
+      window.electronAPI.sendTerminalInput(terminalId, quotedPath + ' ');
+    }
+  }, [reorderTerminals, terminals]);
 
   // Calculate grid layout based on number of terminals
   const gridLayout = useMemo(() => {


### PR DESCRIPTION
## Summary
- Add `closestCenter` collision detection to `DndContext` to fix terminal drag and drop swapping

## Problem
Terminal drag and drop was not identifying valid swap targets when dragging over other terminals. Users could drag terminals but couldn't swap positions with other terminals.

## Solution
The `DndContext` was using the default collision detection algorithm (`rectIntersection`), which requires significant overlap between the dragged element and the drop target. This doesn't work well for grid layouts.

Added `closestCenter` collision detection which detects drop targets based on which one is closest to the center of the dragged element - much more suitable for grid-based terminal reordering.

## Test plan
- [ ] Start the Electron app with `npm run dev`
- [ ] Open multiple terminals in the Agents tab
- [ ] Drag a terminal by its grip handle in the header
- [ ] Verify the terminal can be dropped onto another terminal to swap positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop collision detection in the terminal grid for more responsive and accurate item placement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->