### PR TITLE
fix(github): resolve circular import in PR review context gatherer

### DIFF
--- a/apps/backend/runners/github/context_gatherer.py
+++ b/apps/backend/runners/github/context_gatherer.py
@@ -27,8 +27,10 @@ try:
     from .gh_client import GHClient, PRTooLargeError
     from .services.io_utils import safe_print
 except (ImportError, ValueError, SystemError):
+    # Import from core.io_utils directly to avoid circular import with services package
+    # (services/__init__.py imports pr_review_engine which imports context_gatherer)
+    from core.io_utils import safe_print
     from gh_client import GHClient, PRTooLargeError
-    from services.io_utils import safe_print
 
 # Validation patterns for git refs and paths (defense-in-depth)
 # These patterns allow common valid characters while rejecting potentially dangerous ones

--- a/apps/backend/runners/github/services/__init__.py
+++ b/apps/backend/runners/github/services/__init__.py
@@ -3,14 +3,23 @@ GitHub Orchestrator Services
 ============================
 
 Service layer for GitHub automation workflows.
+
+NOTE: Uses lazy imports to avoid circular dependency with context_gatherer.py.
+The circular import chain was: orchestrator → context_gatherer → services.io_utils
+→ services/__init__ → pr_review_engine → context_gatherer (circular!)
 """
 
-from .autofix_processor import AutoFixProcessor
-from .batch_processor import BatchProcessor
-from .pr_review_engine import PRReviewEngine
-from .prompt_manager import PromptManager
-from .response_parsers import ResponseParser
-from .triage_engine import TriageEngine
+from __future__ import annotations
+
+# Lazy import mapping - classes are loaded on first access
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "AutoFixProcessor": (".autofix_processor", "AutoFixProcessor"),
+    "BatchProcessor": (".batch_processor", "BatchProcessor"),
+    "PRReviewEngine": (".pr_review_engine", "PRReviewEngine"),
+    "PromptManager": (".prompt_manager", "PromptManager"),
+    "ResponseParser": (".response_parsers", "ResponseParser"),
+    "TriageEngine": (".triage_engine", "TriageEngine"),
+}
 
 __all__ = [
     "PromptManager",
@@ -20,3 +29,19 @@ __all__ = [
     "AutoFixProcessor",
     "BatchProcessor",
 ]
+
+# Cache for lazily loaded modules
+_loaded: dict[str, object] = {}
+
+
+def __getattr__(name: str) -> object:
+    """Lazy import handler - loads classes on first access."""
+    if name in _LAZY_IMPORTS:
+        if name not in _loaded:
+            module_name, attr_name = _LAZY_IMPORTS[name]
+            import importlib
+
+            module = importlib.import_module(module_name, __name__)
+            _loaded[name] = getattr(module, attr_name)
+        return _loaded[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- Fix circular import issue that occurs in the build version of the Electron app when running GitHub PR review
- Change `context_gatherer.py` fallback import to use `core.io_utils` instead of `services.io_utils` to avoid triggering the services package initialization
- Convert `services/__init__.py` to use lazy imports via `__getattr__` to prevent future circular import issues

## Root Cause
The circular import chain was:
```
orchestrator.py → context_gatherer.py → services.io_utils 
→ services/__init__.py → pr_review_engine.py → context_gatherer.py (CIRCULAR!)
```

This occurred because `runner.py` modifies `sys.path` which breaks package context for relative imports, causing fallback absolute imports to be used. The fallback `from services.io_utils import safe_print` triggered loading of `services/__init__.py`, which eagerly imported all service classes including `pr_review_engine.py`, which in turn tried to import from the partially-initialized `context_gatherer.py`.

## Fix Strategy
1. **context_gatherer.py**: Import from `core.io_utils` directly in the fallback path (since `services/io_utils.py` just re-exports from `core.io_utils`)
2. **services/__init__.py**: Use lazy imports via `__getattr__` so accessing the services package doesn't immediately load all service classes

## Test plan
- [x] Verified import chain works with simulated `sys.path` setup
- [x] Verified lazy imports load classes correctly on access
- [x] Verified CLI (`runner.py --help`) works without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Resolved circular dependency issues in the backend services module through optimized import handling.
  * Implemented lazy loading mechanism for service classes to improve code initialization efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->