### PR TITLE
feat: Add bulk task import from JSON files

### DIFF
--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -808,6 +808,7 @@ export function App() {
                 {activeView === 'kanban' && (
                   <KanbanBoard
                     tasks={tasks}
+                    projectId={activeProjectId || selectedProjectId!}
                     onTaskClick={handleTaskClick}
                     onNewTaskClick={() => setIsNewTaskDialogOpen(true)}
                     onRefresh={handleRefreshTasks}

--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -41,6 +41,7 @@ function isValidDropColumn(id: string): id is typeof TASK_STATUS_COLUMNS[number]
 
 interface KanbanBoardProps {
   tasks: Task[];
+  projectId: string;
   onTaskClick: (task: Task) => void;
   onNewTaskClick?: () => void;
   onRefresh?: () => void;
@@ -361,7 +362,7 @@ const DroppableColumn = memo(function DroppableColumn({ status, tasks, onTaskCli
   );
 }, droppableColumnPropsAreEqual);
 
-export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isRefreshing }: KanbanBoardProps) {
+export function KanbanBoard({ tasks, projectId, onTaskClick, onNewTaskClick, onRefresh, isRefreshing }: KanbanBoardProps) {
   const { t } = useTranslation(['tasks', 'dialogs', 'common']);
   const { toast } = useToast();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
@@ -443,12 +444,6 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
 
     return grouped;
   }, [filteredTasks]);
-
-  // Get projectId from any task (more reliable than tasks[0] when array might be empty)
-  const projectId = useMemo(() =>
-    tasks.find(task => task.projectId)?.projectId,
-    [tasks]
-  );
 
   const handleArchiveAll = async () => {
     if (!projectId) {
@@ -627,7 +622,7 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
               onStatusChange={handleStatusChange}
               isOver={overColumnId === status}
               onAddClick={status === 'backlog' ? onNewTaskClick : undefined}
-              onImportClick={status === 'backlog' && projectId ? () => setIsImportModalOpen(true) : undefined}
+              onImportClick={status === 'backlog' ? () => setIsImportModalOpen(true) : undefined}
               onArchiveAll={status === 'done' ? handleArchiveAll : undefined}
               archivedCount={status === 'done' ? archivedCount : undefined}
               showArchived={status === 'done' ? showArchived : undefined}
@@ -662,14 +657,12 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
       />
 
       {/* Task file import modal */}
-      {projectId && (
-        <TaskFileImportModal
-          projectId={projectId}
-          open={isImportModalOpen}
-          onOpenChange={setIsImportModalOpen}
-          onImportComplete={() => onRefresh?.()}
-        />
-      )}
+      <TaskFileImportModal
+        projectId={projectId}
+        open={isImportModalOpen}
+        onOpenChange={setIsImportModalOpen}
+        onImportComplete={() => onRefresh?.()}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -444,9 +444,13 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
     return grouped;
   }, [filteredTasks]);
 
+  // Get projectId from any task (more reliable than tasks[0] when array might be empty)
+  const projectId = useMemo(() =>
+    tasks.find(task => task.projectId)?.projectId,
+    [tasks]
+  );
+
   const handleArchiveAll = async () => {
-    // Get projectId from the first task (all tasks should have the same projectId)
-    const projectId = tasks[0]?.projectId;
     if (!projectId) {
       console.error('[KanbanBoard] No projectId found');
       return;
@@ -623,7 +627,7 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
               onStatusChange={handleStatusChange}
               isOver={overColumnId === status}
               onAddClick={status === 'backlog' ? onNewTaskClick : undefined}
-              onImportClick={status === 'backlog' ? () => setIsImportModalOpen(true) : undefined}
+              onImportClick={status === 'backlog' && projectId ? () => setIsImportModalOpen(true) : undefined}
               onArchiveAll={status === 'done' ? handleArchiveAll : undefined}
               archivedCount={status === 'done' ? archivedCount : undefined}
               showArchived={status === 'done' ? showArchived : undefined}
@@ -658,9 +662,9 @@ export function KanbanBoard({ tasks, onTaskClick, onNewTaskClick, onRefresh, isR
       />
 
       {/* Task file import modal */}
-      {tasks[0]?.projectId && (
+      {projectId && (
         <TaskFileImportModal
-          projectId={tasks[0].projectId}
+          projectId={projectId}
           open={isImportModalOpen}
           onOpenChange={setIsImportModalOpen}
           onImportComplete={() => onRefresh?.()}

--- a/apps/frontend/src/renderer/components/task-file-import/TaskFileImportModal.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/TaskFileImportModal.tsx
@@ -1,0 +1,176 @@
+/**
+ * TaskFileImportModal - Main modal component for bulk task import
+ *
+ * Flow:
+ * 1. Show dropzone for file selection
+ * 2. Parse dropped JSON files
+ * 3. Show preview list with selection
+ * 4. Import selected tasks
+ * 5. Show result banner
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Loader2, Upload } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { useTaskFileImportModal } from './hooks';
+import {
+  FileDropzone,
+  TaskPreviewList,
+  ImportSelectionControls,
+  ImportResultBanner
+} from './components';
+import type { TaskFileImportModalProps, TaskFileImportResult } from './types';
+
+export function TaskFileImportModal({
+  projectId,
+  open,
+  onOpenChange,
+  onImportComplete
+}: TaskFileImportModalProps) {
+  const { t } = useTranslation(['tasks', 'common']);
+
+  const {
+    parsedTasks,
+    selectedTaskIds,
+    selectionControls,
+    isParsing,
+    isImporting,
+    error,
+    importResult,
+    handleFileDrop,
+    handleFileSelect,
+    handleImport,
+    resetState
+  } = useTaskFileImportModal({
+    projectId,
+    open,
+    onImportComplete
+  });
+
+  const handleClose = () => {
+    if (!isImporting) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleDone = () => {
+    resetState();
+    onOpenChange(false);
+  };
+
+  const validTaskCount = parsedTasks.filter(t => t.isValid).length;
+  const showDropzone = parsedTasks.length === 0 && !importResult?.success;
+  const showPreview = parsedTasks.length > 0 && !importResult?.success;
+  const showResult = importResult !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[600px] max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Upload className="h-5 w-5" />
+            {t('taskFileImport.title')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('taskFileImport.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Main content area */}
+        <div className="flex-1 min-h-0 overflow-hidden flex flex-col gap-4 py-4">
+          {/* Error display */}
+          {error && !importResult && (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-destructive text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Success/Error result */}
+          {showResult && importResult && (
+            <ImportResultBanner result={importResult} />
+          )}
+
+          {/* Dropzone */}
+          {showDropzone && (
+            <FileDropzone
+              onFileDrop={handleFileDrop}
+              onFileSelect={handleFileSelect}
+              isParsing={isParsing}
+              disabled={isImporting}
+            />
+          )}
+
+          {/* Preview list */}
+          {showPreview && (
+            <>
+              <ImportSelectionControls
+                tasks={parsedTasks}
+                selectedCount={selectedTaskIds.size}
+                onSelectAll={selectionControls.selectAll}
+                onDeselectAll={selectionControls.deselectAll}
+                disabled={isImporting}
+              />
+              <TaskPreviewList
+                tasks={parsedTasks}
+                selectedIds={selectedTaskIds}
+                onToggle={selectionControls.toggleTask}
+                disabled={isImporting}
+              />
+            </>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          {/* Cancel / Close */}
+          {!importResult?.success ? (
+            <Button
+              variant="outline"
+              onClick={handleClose}
+              disabled={isImporting}
+            >
+              {t('common:buttons.cancel')}
+            </Button>
+          ) : (
+            <Button variant="outline" onClick={handleDone}>
+              {t('common:buttons.close')}
+            </Button>
+          )}
+
+          {/* Import button - only show when we have tasks to import */}
+          {showPreview && !importResult?.success && (
+            <Button
+              onClick={handleImport}
+              disabled={selectedTaskIds.size === 0 || isImporting}
+            >
+              {isImporting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {t('taskFileImport.importing')}
+                </>
+              ) : (
+                <>
+                  {t('taskFileImport.importButton', { count: selectedTaskIds.size })}
+                </>
+              )}
+            </Button>
+          )}
+
+          {/* Import more button - after successful import */}
+          {importResult?.success && (
+            <Button onClick={resetState}>
+              {t('taskFileImport.importMore')}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/TaskFileImportModal.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/TaskFileImportModal.tsx
@@ -66,7 +66,6 @@ export function TaskFileImportModal({
     onOpenChange(false);
   };
 
-  const validTaskCount = parsedTasks.filter(t => t.isValid).length;
   const showDropzone = parsedTasks.length === 0 && !importResult?.success;
   const showPreview = parsedTasks.length > 0 && !importResult?.success;
   const showResult = importResult !== null;

--- a/apps/frontend/src/renderer/components/task-file-import/components/FileDropzone.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/FileDropzone.tsx
@@ -1,0 +1,149 @@
+/**
+ * FileDropzone - Drag & drop zone for JSON task files
+ *
+ * Supports:
+ * - Drag & drop multiple .json files
+ * - Click to browse file picker
+ * - Visual feedback during drag-over
+ */
+
+import { useRef, useState, useCallback, type DragEvent, type ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Upload, FileJson, Loader2 } from 'lucide-react';
+import { cn } from '../../../lib/utils';
+
+interface FileDropzoneProps {
+  onFileDrop: (files: FileList) => void;
+  onFileSelect: (files: FileList) => void;
+  isParsing: boolean;
+  disabled?: boolean;
+}
+
+export function FileDropzone({
+  onFileDrop,
+  onFileSelect,
+  isParsing,
+  disabled = false
+}: FileDropzoneProps) {
+  const { t } = useTranslation(['tasks']);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled && !isParsing) {
+      setIsDragOver(true);
+    }
+  }, [disabled, isParsing]);
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    if (disabled || isParsing) return;
+
+    const files = e.dataTransfer?.files;
+    if (files && files.length > 0) {
+      onFileDrop(files);
+    }
+  }, [disabled, isParsing, onFileDrop]);
+
+  const handleFileInputChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      onFileSelect(files);
+    }
+    // Reset input so same files can be selected again
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, [onFileSelect]);
+
+  const handleClick = useCallback(() => {
+    if (!disabled && !isParsing) {
+      fileInputRef.current?.click();
+    }
+  }, [disabled, isParsing]);
+
+  return (
+    <div
+      className={cn(
+        'relative flex flex-col items-center justify-center gap-4 p-8',
+        'border-2 border-dashed rounded-lg transition-all cursor-pointer',
+        'min-h-[200px]',
+        isDragOver && !disabled && !isParsing
+          ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+          : 'border-border hover:border-muted-foreground/50 hover:bg-muted/30',
+        (disabled || isParsing) && 'opacity-50 cursor-not-allowed'
+      )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={t('taskFileImport.dropzone.title')}
+    >
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+        disabled={disabled || isParsing}
+      />
+
+      {/* Icon */}
+      <div className={cn(
+        'flex items-center justify-center w-16 h-16 rounded-full',
+        'bg-muted/50 transition-colors',
+        isDragOver && 'bg-primary/10'
+      )}>
+        {isParsing ? (
+          <Loader2 className="h-8 w-8 text-primary animate-spin" />
+        ) : (
+          <Upload className={cn(
+            'h-8 w-8 transition-colors',
+            isDragOver ? 'text-primary' : 'text-muted-foreground'
+          )} />
+        )}
+      </div>
+
+      {/* Text */}
+      <div className="text-center space-y-1">
+        <p className={cn(
+          'font-medium transition-colors',
+          isDragOver ? 'text-primary' : 'text-foreground'
+        )}>
+          {isParsing
+            ? t('taskFileImport.parsing')
+            : t('taskFileImport.dropzone.title')
+          }
+        </p>
+        {!isParsing && (
+          <p className="text-sm text-muted-foreground">
+            {t('taskFileImport.dropzone.hint')}
+          </p>
+        )}
+      </div>
+
+      {/* Supported formats */}
+      {!isParsing && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <FileJson className="h-4 w-4" />
+          <span>{t('taskFileImport.dropzone.formats')}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/components/FileDropzone.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/FileDropzone.tsx
@@ -7,7 +7,7 @@
  * - Visual feedback during drag-over
  */
 
-import { useRef, useState, useCallback, type DragEvent, type ChangeEvent } from 'react';
+import { useRef, useState, useCallback, type DragEvent, type ChangeEvent, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Upload, FileJson, Loader2 } from 'lucide-react';
 import { cn } from '../../../lib/utils';
@@ -73,6 +73,13 @@ export function FileDropzone({
     }
   }, [disabled, isParsing]);
 
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if ((e.key === 'Enter' || e.key === ' ') && !disabled && !isParsing) {
+      e.preventDefault();
+      fileInputRef.current?.click();
+    }
+  }, [disabled, isParsing]);
+
   return (
     <div
       className={cn(
@@ -88,6 +95,7 @@ export function FileDropzone({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
       aria-label={t('taskFileImport.dropzone.title')}

--- a/apps/frontend/src/renderer/components/task-file-import/components/ImportResultBanner.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/ImportResultBanner.tsx
@@ -1,0 +1,80 @@
+/**
+ * ImportResultBanner - Success/error banner after import
+ */
+
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, AlertTriangle, X } from 'lucide-react';
+import { cn } from '../../../lib/utils';
+import type { TaskFileImportResult } from '../types';
+
+interface ImportResultBannerProps {
+  result: TaskFileImportResult;
+  onDismiss?: () => void;
+}
+
+export function ImportResultBanner({ result, onDismiss }: ImportResultBannerProps) {
+  const { t } = useTranslation(['tasks']);
+
+  const isSuccess = result.success && result.imported > 0;
+  const hasErrors = result.errors && result.errors.length > 0;
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-4 rounded-lg border',
+        isSuccess
+          ? 'bg-success/10 border-success/30 text-success-foreground'
+          : 'bg-destructive/10 border-destructive/30 text-destructive'
+      )}
+      role="alert"
+    >
+      {/* Icon */}
+      {isSuccess ? (
+        <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
+      ) : (
+        <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+      )}
+
+      {/* Content */}
+      <div className="flex-1 space-y-1">
+        <p className="font-medium">
+          {isSuccess
+            ? t('taskFileImport.success.title')
+            : t('taskFileImport.errors.importFailed')
+          }
+        </p>
+        <p className="text-sm opacity-90">
+          {t('taskFileImport.success.message', { count: result.imported })}
+          {result.failed > 0 && `, ${result.failed} failed`}
+        </p>
+
+        {/* Error details */}
+        {hasErrors && (
+          <ul className="text-sm opacity-80 mt-2 space-y-1">
+            {result.errors!.slice(0, 3).map((error, i) => (
+              <li key={i} className="text-xs">
+                {error}
+              </li>
+            ))}
+            {result.errors!.length > 3 && (
+              <li className="text-xs opacity-70">
+                ...and {result.errors!.length - 3} more
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+
+      {/* Dismiss button */}
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          className="p-1 rounded hover:bg-black/10 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/components/ImportResultBanner.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/ImportResultBanner.tsx
@@ -13,7 +13,7 @@ interface ImportResultBannerProps {
 }
 
 export function ImportResultBanner({ result, onDismiss }: ImportResultBannerProps) {
-  const { t } = useTranslation(['tasks']);
+  const { t } = useTranslation(['tasks', 'common']);
 
   const isSuccess = result.success && result.imported > 0;
   const hasErrors = result.errors && result.errors.length > 0;
@@ -45,7 +45,7 @@ export function ImportResultBanner({ result, onDismiss }: ImportResultBannerProp
         </p>
         <p className="text-sm opacity-90">
           {t('taskFileImport.success.message', { count: result.imported })}
-          {result.failed > 0 && `, ${result.failed} failed`}
+          {result.failed > 0 && t('taskFileImport.errors.failedCount', { count: result.failed })}
         </p>
 
         {/* Error details */}
@@ -58,7 +58,7 @@ export function ImportResultBanner({ result, onDismiss }: ImportResultBannerProp
             ))}
             {result.errors!.length > 3 && (
               <li className="text-xs opacity-70">
-                ...and {result.errors!.length - 3} more
+                {t('taskFileImport.errors.moreErrors', { count: result.errors!.length - 3 })}
               </li>
             )}
           </ul>
@@ -68,9 +68,10 @@ export function ImportResultBanner({ result, onDismiss }: ImportResultBannerProp
       {/* Dismiss button */}
       {onDismiss && (
         <button
+          type="button"
           onClick={onDismiss}
           className="p-1 rounded hover:bg-black/10 transition-colors"
-          aria-label="Dismiss"
+          aria-label={t('common:ariaLabels.dismissAriaLabel')}
         >
           <X className="h-4 w-4" />
         </button>

--- a/apps/frontend/src/renderer/components/task-file-import/components/ImportSelectionControls.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/ImportSelectionControls.tsx
@@ -1,0 +1,69 @@
+/**
+ * ImportSelectionControls - Select all / deselect controls and stats
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '../../ui/button';
+import type { ParsedTask } from '../types';
+
+interface ImportSelectionControlsProps {
+  tasks: ParsedTask[];
+  selectedCount: number;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  disabled?: boolean;
+}
+
+export function ImportSelectionControls({
+  tasks,
+  selectedCount,
+  onSelectAll,
+  onDeselectAll,
+  disabled = false
+}: ImportSelectionControlsProps) {
+  const { t } = useTranslation(['tasks']);
+
+  const validCount = tasks.filter(t => t.isValid).length;
+  const invalidCount = tasks.length - validCount;
+
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-border">
+      {/* Selection buttons */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onSelectAll}
+          disabled={disabled || validCount === 0}
+          className="h-7 text-xs"
+        >
+          {t('taskFileImport.selectAll')}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDeselectAll}
+          disabled={disabled || selectedCount === 0}
+          className="h-7 text-xs"
+        >
+          {t('taskFileImport.deselectAll')}
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span>
+          {t('taskFileImport.selectedCount', {
+            count: selectedCount,
+            total: validCount
+          })}
+        </span>
+        {invalidCount > 0 && (
+          <span className="text-destructive">
+            ({invalidCount} invalid)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/components/TaskPreviewCard.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/TaskPreviewCard.tsx
@@ -1,0 +1,145 @@
+/**
+ * TaskPreviewCard - Preview card for a single parsed task
+ *
+ * Shows:
+ * - Checkbox for selection
+ * - Title and truncated description
+ * - Category/priority badges
+ * - Validation error indicator
+ */
+
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, FileJson } from 'lucide-react';
+import { Checkbox } from '../../ui/checkbox';
+import { Badge } from '../../ui/badge';
+import { cn } from '../../../lib/utils';
+import type { ParsedTask } from '../types';
+
+interface TaskPreviewCardProps {
+  task: ParsedTask;
+  isSelected: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Truncate text to a maximum length
+ */
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength).trim() + '...';
+}
+
+/**
+ * Get workflow type badge variant
+ */
+function getWorkflowTypeBadgeVariant(type?: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  switch (type) {
+    case 'feature':
+      return 'default';
+    case 'refactor':
+      return 'secondary';
+    case 'investigation':
+      return 'destructive';
+    default:
+      return 'outline';
+  }
+}
+
+export function TaskPreviewCard({
+  task,
+  isSelected,
+  onToggle,
+  disabled = false
+}: TaskPreviewCardProps) {
+  const { t } = useTranslation(['tasks', 'common']);
+
+  const isDisabled = disabled || !task.isValid;
+
+  // Extract first line of description for preview
+  const descriptionPreview = task.description
+    .split('\n')
+    .find(line => line.trim() && !line.startsWith('#'))
+    ?.trim() || '';
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-3 rounded-lg border transition-colors',
+        isSelected && task.isValid
+          ? 'border-primary bg-primary/5'
+          : 'border-border bg-card',
+        !task.isValid && 'border-destructive/50 bg-destructive/5',
+        isDisabled ? 'opacity-60' : 'hover:bg-muted/30 cursor-pointer'
+      )}
+      onClick={() => !isDisabled && onToggle()}
+      role="button"
+      tabIndex={isDisabled ? -1 : 0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (!isDisabled) onToggle();
+        }
+      }}
+    >
+      {/* Checkbox */}
+      <div className="pt-0.5">
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={() => onToggle()}
+          disabled={isDisabled}
+          aria-label={`Select task: ${task.title}`}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0 space-y-1.5">
+        {/* Header with title and badges */}
+        <div className="flex items-start gap-2 flex-wrap">
+          <h4 className="font-medium text-foreground truncate flex-1 min-w-0">
+            {task.title || t('common:labels.untitled')}
+          </h4>
+
+          {/* Workflow type badge */}
+          {task.workflow_type && (
+            <Badge variant={getWorkflowTypeBadgeVariant(task.workflow_type)} className="text-xs">
+              {task.workflow_type}
+            </Badge>
+          )}
+
+          {/* Priority badge */}
+          {task.priority && task.priority !== 'medium' && (
+            <Badge
+              variant={task.priority === 'high' || task.priority === 'critical' ? 'destructive' : 'outline'}
+              className="text-xs"
+            >
+              {task.priority}
+            </Badge>
+          )}
+        </div>
+
+        {/* Description preview */}
+        {descriptionPreview && (
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {truncate(descriptionPreview, 150)}
+          </p>
+        )}
+
+        {/* Source file */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <FileJson className="h-3 w-3" />
+          <span>{task.sourceFile}</span>
+        </div>
+
+        {/* Validation errors */}
+        {!task.isValid && task.validationErrors.length > 0 && (
+          <div className="flex items-start gap-1.5 text-xs text-destructive mt-2">
+            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>{task.validationErrors.join(', ')}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/components/TaskPreviewList.tsx
+++ b/apps/frontend/src/renderer/components/task-file-import/components/TaskPreviewList.tsx
@@ -1,0 +1,41 @@
+/**
+ * TaskPreviewList - Scrollable list of task preview cards
+ */
+
+import { ScrollArea } from '../../ui/scroll-area';
+import { TaskPreviewCard } from './TaskPreviewCard';
+import type { ParsedTask } from '../types';
+
+interface TaskPreviewListProps {
+  tasks: ParsedTask[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+  disabled?: boolean;
+}
+
+export function TaskPreviewList({
+  tasks,
+  selectedIds,
+  onToggle,
+  disabled = false
+}: TaskPreviewListProps) {
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollArea className="flex-1 -mx-1 px-1">
+      <div className="space-y-2 py-1">
+        {tasks.map((task) => (
+          <TaskPreviewCard
+            key={task.parseId}
+            task={task}
+            isSelected={selectedIds.has(task.parseId)}
+            onToggle={() => onToggle(task.parseId)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/frontend/src/renderer/components/task-file-import/components/index.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/components/index.ts
@@ -1,0 +1,5 @@
+export { FileDropzone } from './FileDropzone';
+export { TaskPreviewCard } from './TaskPreviewCard';
+export { TaskPreviewList } from './TaskPreviewList';
+export { ImportSelectionControls } from './ImportSelectionControls';
+export { ImportResultBanner } from './ImportResultBanner';

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/index.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useFileParser } from './useFileParser';
+export { useTaskSelection } from './useTaskSelection';
+export { useTaskFileImport } from './useTaskFileImport';
+export { useTaskFileImportModal } from './useTaskFileImportModal';

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useFileParser.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useFileParser.ts
@@ -1,0 +1,185 @@
+/**
+ * useFileParser - Hook for parsing JSON task files
+ *
+ * Handles:
+ * - Reading files via FileReader API
+ * - JSON parsing with error handling
+ * - Schema validation
+ * - Converting to ParsedTask format
+ */
+
+import { useState, useCallback } from 'react';
+import type { TaskFileEntry, ParsedTask } from '../types';
+
+interface UseFileParserOptions {
+  onError?: (error: string) => void;
+}
+
+interface UseFileParserReturn {
+  parsedTasks: ParsedTask[];
+  isParsing: boolean;
+  parseError: string | null;
+  parseFiles: (files: FileList) => Promise<void>;
+  clearParsedTasks: () => void;
+}
+
+/**
+ * Read file content as text using FileReader API
+ */
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * Validate a task entry against the expected schema
+ */
+function validateTaskEntry(task: unknown, filename: string): { isValid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!task || typeof task !== 'object') {
+    errors.push('Invalid JSON structure');
+    return { isValid: false, errors };
+  }
+
+  const entry = task as Record<string, unknown>;
+
+  // Required fields
+  if (!entry.title || typeof entry.title !== 'string') {
+    errors.push('Missing or invalid "title" field');
+  }
+  if (!entry.description || typeof entry.description !== 'string') {
+    errors.push('Missing or invalid "description" field');
+  }
+
+  // Optional field validation
+  const validWorkflowTypes = ['feature', 'refactor', 'investigation', 'migration', 'simple'];
+  if (entry.workflow_type && !validWorkflowTypes.includes(entry.workflow_type as string)) {
+    errors.push(`Invalid workflow_type: ${entry.workflow_type}`);
+  }
+
+  const validComplexities = ['simple', 'standard', 'complex'];
+  if (entry.complexity && !validComplexities.includes(entry.complexity as string)) {
+    errors.push(`Invalid complexity: ${entry.complexity}`);
+  }
+
+  const validPriorities = ['low', 'medium', 'high', 'critical'];
+  if (entry.priority && !validPriorities.includes(entry.priority as string)) {
+    errors.push(`Invalid priority: ${entry.priority}`);
+  }
+
+  if (entry.files && !Array.isArray(entry.files)) {
+    errors.push('"files" must be an array');
+  }
+
+  if (entry.dependencies && !Array.isArray(entry.dependencies)) {
+    errors.push('"dependencies" must be an array');
+  }
+
+  if (entry.phase !== undefined && typeof entry.phase !== 'number') {
+    errors.push('"phase" must be a number');
+  }
+
+  return { isValid: errors.length === 0, errors };
+}
+
+/**
+ * Parse a single JSON file into a ParsedTask
+ */
+async function parseTaskFile(file: File): Promise<ParsedTask | null> {
+  // Skip index files
+  if (file.name.startsWith('_')) {
+    return null;
+  }
+
+  // Only process .json files
+  if (!file.name.endsWith('.json')) {
+    return null;
+  }
+
+  try {
+    const content = await readFileAsText(file);
+    const parsed = JSON.parse(content) as TaskFileEntry;
+    const validation = validateTaskEntry(parsed, file.name);
+
+    return {
+      ...parsed,
+      parseId: crypto.randomUUID(),
+      sourceFile: file.name,
+      isValid: validation.isValid,
+      validationErrors: validation.errors
+    };
+  } catch (error) {
+    // Return invalid task with parse error
+    return {
+      title: file.name.replace('.json', ''),
+      description: '',
+      parseId: crypto.randomUUID(),
+      sourceFile: file.name,
+      isValid: false,
+      validationErrors: [error instanceof Error ? error.message : 'Failed to parse JSON']
+    };
+  }
+}
+
+export function useFileParser(options: UseFileParserOptions = {}): UseFileParserReturn {
+  const { onError } = options;
+
+  const [parsedTasks, setParsedTasks] = useState<ParsedTask[]>([]);
+  const [isParsing, setIsParsing] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const parseFiles = useCallback(async (files: FileList) => {
+    if (files.length === 0) return;
+
+    setIsParsing(true);
+    setParseError(null);
+
+    try {
+      const tasks: ParsedTask[] = [];
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        const parsed = await parseTaskFile(file);
+        if (parsed) {
+          tasks.push(parsed);
+        }
+      }
+
+      if (tasks.length === 0) {
+        const error = 'No valid JSON task files found';
+        setParseError(error);
+        onError?.(error);
+        return;
+      }
+
+      // Sort by filename (to maintain order like 001, 002, etc.)
+      tasks.sort((a, b) => a.sourceFile.localeCompare(b.sourceFile));
+
+      setParsedTasks(tasks);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to parse files';
+      setParseError(errorMessage);
+      onError?.(errorMessage);
+    } finally {
+      setIsParsing(false);
+    }
+  }, [onError]);
+
+  const clearParsedTasks = useCallback(() => {
+    setParsedTasks([]);
+    setParseError(null);
+  }, []);
+
+  return {
+    parsedTasks,
+    isParsing,
+    parseError,
+    parseFiles,
+    clearParsedTasks
+  };
+}

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useFileParser.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useFileParser.ts
@@ -38,7 +38,7 @@ function readFileAsText(file: File): Promise<string> {
 /**
  * Validate a task entry against the expected schema
  */
-function validateTaskEntry(task: unknown, filename: string): { isValid: boolean; errors: string[] } {
+function validateTaskEntry(task: unknown): { isValid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   if (!task || typeof task !== 'object') {
@@ -104,7 +104,7 @@ async function parseTaskFile(file: File): Promise<ParsedTask | null> {
   try {
     const content = await readFileAsText(file);
     const parsed = JSON.parse(content) as TaskFileEntry;
-    const validation = validateTaskEntry(parsed, file.name);
+    const validation = validateTaskEntry(parsed);
 
     return {
       ...parsed,

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImport.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImport.ts
@@ -1,0 +1,116 @@
+/**
+ * useTaskFileImport - Hook for importing tasks into the project
+ *
+ * Uses the existing createTask function from task-store
+ * to create tasks from parsed JSON files
+ */
+
+import { useState, useCallback } from 'react';
+import { createTask } from '../../../stores/task-store';
+import type { ParsedTask, TaskFileImportResult } from '../types';
+import { mapWorkflowTypeToCategory, mapPriority, mapComplexity } from '../types';
+import type { TaskMetadata } from '../../../../shared/types';
+
+interface UseTaskFileImportOptions {
+  projectId: string;
+  onImportComplete?: (result: TaskFileImportResult) => void;
+}
+
+interface UseTaskFileImportReturn {
+  isImporting: boolean;
+  importResult: TaskFileImportResult | null;
+  importError: string | null;
+  handleImport: (tasks: ParsedTask[], selectedIds: Set<string>) => Promise<void>;
+  resetImportState: () => void;
+}
+
+export function useTaskFileImport(options: UseTaskFileImportOptions): UseTaskFileImportReturn {
+  const { projectId, onImportComplete } = options;
+
+  const [isImporting, setIsImporting] = useState(false);
+  const [importResult, setImportResult] = useState<TaskFileImportResult | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleImport = useCallback(async (tasks: ParsedTask[], selectedIds: Set<string>) => {
+    if (selectedIds.size === 0) return;
+
+    setIsImporting(true);
+    setImportError(null);
+    setImportResult(null);
+
+    const errors: string[] = [];
+    let importedCount = 0;
+    let failedCount = 0;
+
+    // Get selected tasks in order
+    const selectedTasks = tasks
+      .filter(t => selectedIds.has(t.parseId) && t.isValid)
+      .sort((a, b) => a.sourceFile.localeCompare(b.sourceFile));
+
+    for (const task of selectedTasks) {
+      try {
+        // Build metadata from task fields
+        const metadata: TaskMetadata = {
+          sourceType: 'import'
+        };
+
+        // Map optional fields
+        const category = mapWorkflowTypeToCategory(task.workflow_type);
+        if (category) metadata.category = category;
+
+        const priority = mapPriority(task.priority);
+        if (priority) metadata.priority = priority;
+
+        const complexity = mapComplexity(task.complexity);
+        if (complexity) metadata.complexity = complexity;
+
+        // Create the task
+        const created = await createTask(
+          projectId,
+          task.title,
+          task.description,
+          metadata
+        );
+
+        if (created) {
+          importedCount++;
+        } else {
+          failedCount++;
+          errors.push(`Failed to create task: ${task.title}`);
+        }
+      } catch (error) {
+        failedCount++;
+        errors.push(`Error creating "${task.title}": ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    const result: TaskFileImportResult = {
+      success: failedCount === 0,
+      imported: importedCount,
+      failed: failedCount,
+      errors: errors.length > 0 ? errors : undefined
+    };
+
+    setImportResult(result);
+
+    if (errors.length > 0) {
+      setImportError(`${failedCount} task(s) failed to import`);
+    }
+
+    onImportComplete?.(result);
+    setIsImporting(false);
+  }, [projectId, onImportComplete]);
+
+  const resetImportState = useCallback(() => {
+    setImportResult(null);
+    setImportError(null);
+  }, []);
+
+  return {
+    isImporting,
+    importResult,
+    importError,
+    handleImport,
+    resetImportState
+  };
+}

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImport.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImport.ts
@@ -51,7 +51,7 @@ export function useTaskFileImport(options: UseTaskFileImportOptions): UseTaskFil
       try {
         // Build metadata from task fields
         const metadata: TaskMetadata = {
-          sourceType: 'import'
+          sourceType: 'imported'
         };
 
         // Map optional fields

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImportModal.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImportModal.ts
@@ -1,0 +1,106 @@
+/**
+ * useTaskFileImportModal - Main orchestration hook
+ *
+ * Combines all the sub-hooks into a single interface
+ * for the TaskFileImportModal component
+ */
+
+import { useCallback, useEffect } from 'react';
+import { useFileParser } from './useFileParser';
+import { useTaskSelection } from './useTaskSelection';
+import { useTaskFileImport } from './useTaskFileImport';
+import type { TaskFileImportState, TaskFileImportResult } from '../types';
+
+interface UseTaskFileImportModalOptions {
+  projectId: string;
+  open: boolean;
+  onImportComplete?: (result: TaskFileImportResult) => void;
+}
+
+export function useTaskFileImportModal(options: UseTaskFileImportModalOptions): TaskFileImportState {
+  const { projectId, open, onImportComplete } = options;
+
+  // File parsing
+  const {
+    parsedTasks,
+    isParsing,
+    parseError,
+    parseFiles,
+    clearParsedTasks
+  } = useFileParser();
+
+  // Task selection
+  const {
+    selectedTaskIds,
+    setSelectedTaskIds,
+    selectionControls
+  } = useTaskSelection(parsedTasks);
+
+  // Import operation
+  const {
+    isImporting,
+    importResult,
+    importError,
+    handleImport: doImport,
+    resetImportState
+  } = useTaskFileImport({ projectId, onImportComplete });
+
+  // Reset state when modal closes
+  useEffect(() => {
+    if (!open) {
+      clearParsedTasks();
+      setSelectedTaskIds(new Set());
+      resetImportState();
+    }
+  }, [open, clearParsedTasks, setSelectedTaskIds, resetImportState]);
+
+  // Auto-select all valid tasks when parsed
+  useEffect(() => {
+    if (parsedTasks.length > 0 && selectedTaskIds.size === 0) {
+      selectionControls.selectAll();
+    }
+  }, [parsedTasks, selectedTaskIds.size, selectionControls]);
+
+  // Handle file drop
+  const handleFileDrop = useCallback(async (files: FileList) => {
+    clearParsedTasks();
+    resetImportState();
+    await parseFiles(files);
+  }, [clearParsedTasks, resetImportState, parseFiles]);
+
+  // Handle file select (same as drop)
+  const handleFileSelect = useCallback(async (files: FileList) => {
+    clearParsedTasks();
+    resetImportState();
+    await parseFiles(files);
+  }, [clearParsedTasks, resetImportState, parseFiles]);
+
+  // Handle import
+  const handleImport = useCallback(async () => {
+    await doImport(parsedTasks, selectedTaskIds);
+  }, [doImport, parsedTasks, selectedTaskIds]);
+
+  // Reset all state
+  const resetState = useCallback(() => {
+    clearParsedTasks();
+    setSelectedTaskIds(new Set());
+    resetImportState();
+  }, [clearParsedTasks, setSelectedTaskIds, resetImportState]);
+
+  // Combine errors
+  const error = parseError || importError;
+
+  return {
+    parsedTasks,
+    selectedTaskIds,
+    selectionControls,
+    isParsing,
+    isImporting,
+    error,
+    importResult,
+    handleFileDrop,
+    handleFileSelect,
+    handleImport,
+    resetState
+  };
+}

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImportModal.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskFileImportModal.ts
@@ -69,11 +69,7 @@ export function useTaskFileImportModal(options: UseTaskFileImportModalOptions): 
   }, [clearParsedTasks, resetImportState, parseFiles]);
 
   // Handle file select (same as drop)
-  const handleFileSelect = useCallback(async (files: FileList) => {
-    clearParsedTasks();
-    resetImportState();
-    await parseFiles(files);
-  }, [clearParsedTasks, resetImportState, parseFiles]);
+  const handleFileSelect = handleFileDrop;
 
   // Handle import
   const handleImport = useCallback(async () => {

--- a/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskSelection.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/hooks/useTaskSelection.ts
@@ -1,0 +1,71 @@
+/**
+ * useTaskSelection - Hook for managing task selection state
+ *
+ * Adapted from useIssueSelection pattern in linear-import
+ * Provides selection controls for bulk task import
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import type { ParsedTask } from '../types';
+
+interface UseTaskSelectionReturn {
+  selectedTaskIds: Set<string>;
+  setSelectedTaskIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  selectionControls: {
+    selectAll: () => void;
+    deselectAll: () => void;
+    toggleTask: (id: string) => void;
+    isAllSelected: boolean;
+    isSomeSelected: boolean;
+  };
+}
+
+export function useTaskSelection(tasks: ParsedTask[]): UseTaskSelectionReturn {
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
+
+  // Only consider valid tasks for selection
+  const validTasks = useMemo(() => tasks.filter(t => t.isValid), [tasks]);
+
+  const selectAll = useCallback(() => {
+    setSelectedTaskIds(new Set(validTasks.map(t => t.parseId)));
+  }, [validTasks]);
+
+  const deselectAll = useCallback(() => {
+    setSelectedTaskIds(new Set());
+  }, []);
+
+  const toggleTask = useCallback((id: string) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const isAllSelected = useMemo(() => {
+    if (validTasks.length === 0) return false;
+    return validTasks.every(t => selectedTaskIds.has(t.parseId));
+  }, [validTasks, selectedTaskIds]);
+
+  const isSomeSelected = useMemo(() => {
+    return selectedTaskIds.size > 0;
+  }, [selectedTaskIds]);
+
+  const selectionControls = useMemo(() => ({
+    selectAll,
+    deselectAll,
+    toggleTask,
+    isAllSelected,
+    isSomeSelected
+  }), [selectAll, deselectAll, toggleTask, isAllSelected, isSomeSelected]);
+
+  return {
+    selectedTaskIds,
+    setSelectedTaskIds,
+    selectionControls
+  };
+}

--- a/apps/frontend/src/renderer/components/task-file-import/index.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/index.ts
@@ -1,0 +1,7 @@
+export { TaskFileImportModal } from './TaskFileImportModal';
+export type {
+  TaskFileImportModalProps,
+  TaskFileImportResult,
+  TaskFileEntry,
+  ParsedTask
+} from './types';

--- a/apps/frontend/src/renderer/components/task-file-import/types.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Types for Task File Import feature
+ *
+ * These types define the JSON schema for imported task files
+ * and the internal state management types.
+ */
+
+import type { TaskCategory, TaskPriority, TaskComplexity, TaskImpact } from '../../../shared/types';
+
+/**
+ * JSON file format for a single task
+ * This matches the schema defined in the auto-claude-generator skill
+ */
+export interface TaskFileEntry {
+  title: string;
+  description: string;
+  workflow_type?: 'feature' | 'refactor' | 'investigation' | 'migration' | 'simple';
+  complexity?: 'simple' | 'standard' | 'complex';
+  priority?: 'low' | 'medium' | 'high' | 'critical';
+  category?: string;
+  files?: string[];
+  dependencies?: string[];
+  phase?: number;
+}
+
+/**
+ * Parsed task with additional metadata for selection/validation
+ */
+export interface ParsedTask extends TaskFileEntry {
+  /** Unique ID for selection tracking */
+  parseId: string;
+  /** Original filename */
+  sourceFile: string;
+  /** Whether the task passed validation */
+  isValid: boolean;
+  /** List of validation errors if invalid */
+  validationErrors: string[];
+}
+
+/**
+ * Props for the main import modal
+ */
+export interface TaskFileImportModalProps {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImportComplete?: (result: TaskFileImportResult) => void;
+}
+
+/**
+ * Result of the import operation
+ */
+export interface TaskFileImportResult {
+  success: boolean;
+  imported: number;
+  failed: number;
+  errors?: string[];
+}
+
+/**
+ * State returned by the main orchestration hook
+ */
+export interface TaskFileImportState {
+  // Parsed tasks
+  parsedTasks: ParsedTask[];
+  // Selection
+  selectedTaskIds: Set<string>;
+  selectionControls: {
+    selectAll: () => void;
+    deselectAll: () => void;
+    toggleTask: (id: string) => void;
+    isAllSelected: boolean;
+    isSomeSelected: boolean;
+  };
+  // Loading states
+  isParsing: boolean;
+  isImporting: boolean;
+  // Results
+  error: string | null;
+  importResult: TaskFileImportResult | null;
+  // Handlers
+  handleFileDrop: (files: FileList) => Promise<void>;
+  handleFileSelect: (files: FileList) => Promise<void>;
+  handleImport: () => Promise<void>;
+  resetState: () => void;
+}
+
+/**
+ * Map workflow_type to TaskCategory
+ */
+export function mapWorkflowTypeToCategory(workflowType?: string): TaskCategory | undefined {
+  const mapping: Record<string, TaskCategory> = {
+    feature: 'feature',
+    refactor: 'refactor',
+    investigation: 'bug',
+    migration: 'infrastructure',
+    simple: 'chore'
+  };
+  return workflowType ? mapping[workflowType] : undefined;
+}
+
+/**
+ * Map priority string to TaskPriority
+ */
+export function mapPriority(priority?: string): TaskPriority | undefined {
+  const mapping: Record<string, TaskPriority> = {
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    critical: 'critical'
+  };
+  return priority ? mapping[priority] : undefined;
+}
+
+/**
+ * Map complexity string to TaskComplexity
+ */
+export function mapComplexity(complexity?: string): TaskComplexity | undefined {
+  const mapping: Record<string, TaskComplexity> = {
+    simple: 'simple',
+    standard: 'medium',
+    complex: 'complex'
+  };
+  return complexity ? mapping[complexity] : undefined;
+}

--- a/apps/frontend/src/renderer/components/task-file-import/types.ts
+++ b/apps/frontend/src/renderer/components/task-file-import/types.ts
@@ -5,7 +5,7 @@
  * and the internal state management types.
  */
 
-import type { TaskCategory, TaskPriority, TaskComplexity, TaskImpact } from '../../../shared/types';
+import type { TaskCategory, TaskPriority, TaskComplexity } from '../../../shared/types';
 
 /**
  * JSON file format for a single task
@@ -91,10 +91,10 @@ export interface TaskFileImportState {
 export function mapWorkflowTypeToCategory(workflowType?: string): TaskCategory | undefined {
   const mapping: Record<string, TaskCategory> = {
     feature: 'feature',
-    refactor: 'refactor',
-    investigation: 'bug',
+    refactor: 'refactoring',
+    investigation: 'bug_fix',
     migration: 'infrastructure',
-    simple: 'chore'
+    simple: 'infrastructure'
   };
   return workflowType ? mapping[workflowType] : undefined;
 }
@@ -107,7 +107,8 @@ export function mapPriority(priority?: string): TaskPriority | undefined {
     low: 'low',
     medium: 'medium',
     high: 'high',
-    critical: 'critical'
+    critical: 'urgent',
+    urgent: 'urgent'
   };
   return priority ? mapping[priority] : undefined;
 }
@@ -117,7 +118,7 @@ export function mapPriority(priority?: string): TaskPriority | undefined {
  */
 export function mapComplexity(complexity?: string): TaskComplexity | undefined {
   const mapping: Record<string, TaskComplexity> = {
-    simple: 'simple',
+    simple: 'small',
     standard: 'medium',
     complex: 'complex'
   };

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -240,5 +240,31 @@
   },
   "subtasks": {
     "untitled": "Untitled subtask"
+  },
+  "taskFileImport": {
+    "title": "Import Tasks from File",
+    "description": "Drop JSON task files or click to browse",
+    "dropzone": {
+      "title": "Drop JSON files here",
+      "hint": "or click to browse",
+      "formats": "Supports .json files"
+    },
+    "parsing": "Parsing files...",
+    "importing": "Importing...",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "selectedCount": "{{count}} of {{total}} selected",
+    "importButton": "Import {{count}} Task(s)",
+    "importMore": "Import More",
+    "success": {
+      "title": "Import successful",
+      "message": "{{count}} task(s) imported"
+    },
+    "errors": {
+      "invalidJson": "Invalid JSON file",
+      "noTasks": "No valid tasks found",
+      "missingFields": "Missing required fields",
+      "importFailed": "Some tasks failed to import"
+    }
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -264,7 +264,9 @@
       "invalidJson": "Invalid JSON file",
       "noTasks": "No valid tasks found",
       "missingFields": "Missing required fields",
-      "importFailed": "Some tasks failed to import"
+      "importFailed": "Some tasks failed to import",
+      "failedCount": ", {{count}} failed",
+      "moreErrors": "...and {{count}} more"
     }
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -240,5 +240,31 @@
   },
   "subtasks": {
     "untitled": "Sous-tâche sans titre"
+  },
+  "taskFileImport": {
+    "title": "Importer des tâches depuis un fichier",
+    "description": "Déposez des fichiers JSON ou cliquez pour parcourir",
+    "dropzone": {
+      "title": "Déposez les fichiers JSON ici",
+      "hint": "ou cliquez pour parcourir",
+      "formats": "Fichiers .json pris en charge"
+    },
+    "parsing": "Analyse des fichiers...",
+    "importing": "Importation...",
+    "selectAll": "Tout sélectionner",
+    "deselectAll": "Tout désélectionner",
+    "selectedCount": "{{count}} sur {{total}} sélectionné(s)",
+    "importButton": "Importer {{count}} tâche(s)",
+    "importMore": "Importer plus",
+    "success": {
+      "title": "Importation réussie",
+      "message": "{{count}} tâche(s) importée(s)"
+    },
+    "errors": {
+      "invalidJson": "Fichier JSON invalide",
+      "noTasks": "Aucune tâche valide trouvée",
+      "missingFields": "Champs requis manquants",
+      "importFailed": "Certaines tâches n'ont pas pu être importées"
+    }
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -264,7 +264,9 @@
       "invalidJson": "Fichier JSON invalide",
       "noTasks": "Aucune tâche valide trouvée",
       "missingFields": "Champs requis manquants",
-      "importFailed": "Certaines tâches n'ont pas pu être importées"
+      "importFailed": "Certaines tâches n'ont pas pu être importées",
+      "failedCount": ", {{count}} échoué(s)",
+      "moreErrors": "...et {{count}} de plus"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add drag & drop import for JSON task files
- Support multiple file selection
- Preview parsed tasks with validation before import
- Bulk selection controls (select all/deselect)
- New import button in Kanban backlog header

## Features

- **FileDropzone**: Drag & drop area with visual feedback
- **TaskPreviewCard**: Shows parsed task with validation status
- **TaskPreviewList**: Scrollable list with selection
- **ImportSelectionControls**: Select all/deselect controls
- **TaskFileImportModal**: Main modal orchestrating the flow

## JSON Format

Single task file (`001-feature.json`):
```json
{
  "title": "Feature Name",
  "description": "Task description with markdown",
  "workflow_type": "feature",
  "complexity": "standard",
  "priority": "medium"
}
```

## Test plan

- [ ] Drop single JSON file into dropzone
- [ ] Drop multiple JSON files
- [ ] Verify validation errors show for invalid files
- [ ] Select/deselect tasks
- [ ] Import selected tasks
- [ ] Verify tasks appear in backlog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk task import from JSON via drag-and-drop or file picker.
  * Modal-driven import flow with parsed preview, per-task selection, and bulk selection controls.
  * Import result banner summarizing success/errors with dismiss option.
  * Import action added to the Kanban backlog column.
  * English and French translations for the import UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->