### PR TITLE
feat(github-review): wait for CI checks before starting AI PR review

### DIFF
--- a/apps/backend/runners/github/test_enhanced_pr_review.py
+++ b/apps/backend/runners/github/test_enhanced_pr_review.py
@@ -56,7 +56,6 @@ def test_ai_comment_verdict_enum():
     assert AICommentVerdict.NICE_TO_HAVE.value == "nice_to_have"
     assert AICommentVerdict.TRIVIAL.value == "trivial"
     assert AICommentVerdict.FALSE_POSITIVE.value == "false_positive"
-    assert AICommentVerdict.ADDRESSED.value == "addressed"
 
     print("  ✅ AICommentVerdict enum: PASS")
 

--- a/tests/test_structured_outputs.py
+++ b/tests/test_structured_outputs.py
@@ -432,7 +432,6 @@ class TestAICommentTriage:
             "nice_to_have",
             "trivial",
             "false_positive",
-            "addressed",
         ]:
             data = {
                 "comment_id": 1,


### PR DESCRIPTION
## Summary
- Adds polling mechanism that waits for CI checks to complete before starting AI PR review
- Polls every 20 seconds, only blocks on `in_progress` status (not `queued` to avoid CLA/licensing delays)
- 30-minute timeout prevents infinite waiting
- Graceful error handling proceeds with review on API errors

## Test plan
- [ ] Trigger AI PR review on a PR with running CI checks - should show "Waiting for CI checks..." message
- [ ] Verify review starts after CI completes or times out
- [ ] Test follow-up review also waits for CI checks
- [ ] Test with no CI checks - should proceed immediately
- [ ] Test with API error - should proceed with review (graceful fallback)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR reviews now wait for CI checks before starting, with progress reporting and improved timeout handling

* **Bug Fixes**
  * Reduced race conditions when transitioning from CI wait to active reviews
  * Cancellation reliably aborts pending CI waits and cleans up pending state

* **Tests**
  * Added "addressed" as a valid AI comment verdict and updated tests accordingly

* **Chores**
  * Improved cleanup of pending review state on error or early exit

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->