### PR TITLE
fix(terminal): add scroll area to worktree dropdown to prevent overflow

### DIFF
--- a/apps/frontend/src/renderer/components/terminal/WorktreeSelector.tsx
+++ b/apps/frontend/src/renderer/components/terminal/WorktreeSelector.tsx
@@ -170,21 +170,20 @@ export function WorktreeSelector({
           {t('terminal:worktree.createNew')}
         </DropdownMenuItem>
 
+        {/* Fixed separator between "Create New" and scrollable content */}
+        <DropdownMenuSeparator />
+
         {/* Scrollable content */}
         <ScrollArea className="max-h-[300px]">
           {isLoading ? (
-            <>
-              <DropdownMenuSeparator />
-              <div className="flex items-center justify-center py-2">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              </div>
-            </>
+            <div className="flex items-center justify-center py-2">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
           ) : (
             <>
               {/* Terminal Worktrees Section */}
               {worktrees.length > 0 && (
                 <>
-                  <DropdownMenuSeparator />
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
                     {t('terminal:worktree.existing')}
                   </div>


### PR DESCRIPTION
## Summary
- Wrap worktree dropdown list in `ScrollArea` with max-height of 300px
- Prevents dropdown from overflowing the screen when many worktrees exist
- Uses existing UI component, no new dependencies

## Test plan
- [ ] Open terminal with a project that has multiple worktrees
- [ ] Click worktree selector dropdown
- [ ] Verify dropdown is scrollable and doesn't overflow screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scrollable interface to worktree selector for improved navigation
  * Introduced dedicated delete buttons for worktree items with confirmation dialogs
  * Reorganized worktree selector layout with consistent visual structure and separators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->