### PR TITLE
fix(terminal): persist worktree label after app restart

### DIFF
--- a/apps/frontend/src/main/terminal/terminal-lifecycle.ts
+++ b/apps/frontend/src/main/terminal/terminal-lifecycle.ts
@@ -131,6 +131,8 @@ export async function restoreTerminal(
   const storedSession = storedSessions.find(s => s.id === session.id);
   const storedIsClaudeMode = storedSession?.isClaudeMode ?? session.isClaudeMode;
   const storedClaudeSessionId = storedSession?.claudeSessionId ?? session.claudeSessionId;
+  // Get worktreeConfig from stored session (authoritative) since renderer-passed value may be stale
+  const storedWorktreeConfig = storedSession?.worktreeConfig ?? session.worktreeConfig;
 
   debugLog('[TerminalLifecycle] Restoring terminal session:', session.id,
     'Passed Claude mode:', session.isClaudeMode,
@@ -171,8 +173,9 @@ export async function restoreTerminal(
   terminal.title = session.title;
   // Only restore worktree config if the worktree directory still exists
   // (effectiveCwd matching session.cwd means no fallback was needed)
+  // Use storedWorktreeConfig (from disk) as the authoritative source
   if (effectiveCwd === session.cwd) {
-    terminal.worktreeConfig = session.worktreeConfig;
+    terminal.worktreeConfig = storedWorktreeConfig;
   } else {
     // Worktree was deleted, clear the config and update terminal's cwd
     terminal.worktreeConfig = undefined;


### PR DESCRIPTION
## Summary
- Fix terminal worktree labels disappearing after app restart
- Use `storedWorktreeConfig` from disk (authoritative) instead of `session.worktreeConfig` from renderer (potentially stale)
- Follows existing pattern for `isClaudeMode` and `claudeSessionId`

## Problem
When entering a worktree in an agent terminal, the terminal header correctly displays the worktree name badge during that session. However, after closing and reopening the app:
- The terminal is still in the worktree directory (cwd correct) ✅
- The worktree label in the header no longer displays ❌

## Root Cause
During terminal restoration, the main process used `session.worktreeConfig` passed from the renderer (which may be stale/undefined) instead of `storedSession.worktreeConfig` from disk (authoritative source).

## Test plan
- [ ] Create a terminal and switch to a worktree
- [ ] Verify label shows in terminal header
- [ ] Close app completely
- [ ] Reopen app
- [ ] Verify terminal is in worktree directory AND label displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Terminal working directory configuration is now more reliably restored from persisted session state, ensuring consistent behavior across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->