### PR TITLE
Add Search Functionality to Branch Selector

### DIFF
--- a/apps/frontend/src/renderer/components/TaskCreationWizard.tsx
+++ b/apps/frontend/src/renderer/components/TaskCreationWizard.tsx
@@ -15,13 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader2, ChevronDown, ChevronUp, RotateCcw, FolderTree, GitBranch, Info } from 'lucide-react';
 import { Button } from './ui/button';
 import { Label } from './ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from './ui/select';
+import { Combobox, type ComboboxOption } from './ui/combobox';
 import { TaskModalLayout } from './task-form/TaskModalLayout';
 import { TaskFormFields } from './task-form/TaskFormFields';
 import { type FileReferenceData } from './task-form/useImageUpload';
@@ -82,6 +76,22 @@ export function TaskCreationWizard({
     const project = projects.find((p) => p.id === projectId);
     return project?.path ?? null;
   }, [projects, projectId]);
+
+  // Convert branches to ComboboxOption[] format for searchable dropdown
+  const branchOptions: ComboboxOption[] = useMemo(() => {
+    const options: ComboboxOption[] = [
+      {
+        value: PROJECT_DEFAULT_BRANCH,
+        label: projectDefaultBranch
+          ? t('tasks:wizard.gitOptions.useProjectDefaultWithBranch', { branch: projectDefaultBranch })
+          : t('tasks:wizard.gitOptions.useProjectDefault')
+      }
+    ];
+    branches.forEach((branch) => {
+      options.push({ value: branch, label: branch });
+    });
+    return options;
+  }, [branches, projectDefaultBranch, t]);
 
   // Classification fields
   const [category, setCategory] = useState<TaskCategory | ''>('');
@@ -684,31 +694,20 @@ export function TaskCreationWizard({
               <Label htmlFor="base-branch" className="text-sm font-medium text-foreground">
                 {t('tasks:wizard.gitOptions.baseBranchLabel')}
               </Label>
-              <Select
+              <Combobox
+                id="base-branch"
                 value={baseBranch}
                 onValueChange={setBaseBranch}
+                options={branchOptions}
+                placeholder={projectDefaultBranch
+                  ? t('tasks:wizard.gitOptions.useProjectDefaultWithBranch', { branch: projectDefaultBranch })
+                  : t('tasks:wizard.gitOptions.useProjectDefault')
+                }
+                searchPlaceholder={t('tasks:wizard.gitOptions.searchBranches')}
+                emptyMessage={t('tasks:wizard.gitOptions.noBranchesFound')}
                 disabled={isCreating || isLoadingBranches}
-              >
-                <SelectTrigger id="base-branch" className="h-9">
-                  <SelectValue placeholder={projectDefaultBranch
-                    ? t('tasks:wizard.gitOptions.useProjectDefaultWithBranch', { branch: projectDefaultBranch })
-                    : t('tasks:wizard.gitOptions.useProjectDefault')
-                  } />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={PROJECT_DEFAULT_BRANCH}>
-                    {projectDefaultBranch
-                      ? t('tasks:wizard.gitOptions.useProjectDefaultWithBranch', { branch: projectDefaultBranch })
-                      : t('tasks:wizard.gitOptions.useProjectDefault')
-                    }
-                  </SelectItem>
-                  {branches.map((branch) => (
-                    <SelectItem key={branch} value={branch}>
-                      {branch}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                className="h-9"
+              />
               <p className="text-xs text-muted-foreground">
                 {t('tasks:wizard.gitOptions.helpText')}
               </p>

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -151,6 +151,8 @@
       "baseBranchLabel": "Base Branch (optional)",
       "useProjectDefault": "Use project default",
       "useProjectDefaultWithBranch": "Use project default ({{branch}})",
+      "searchBranches": "Search branches...",
+      "noBranchesFound": "No branches found",
       "helpText": "Override the branch this task's worktree will be created from. Leave empty to use the project's configured default branch.",
       "useWorktreeLabel": "Use isolated workspace (recommended)",
       "useWorktreeDescription": "Creates changes in a separate git worktree for safe review before merging. Disable to build directly in your project (faster but riskier)."

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -151,6 +151,8 @@
       "baseBranchLabel": "Branche de base (optionnel)",
       "useProjectDefault": "Utiliser la branche par défaut du projet",
       "useProjectDefaultWithBranch": "Utiliser la branche par défaut du projet ({{branch}})",
+      "searchBranches": "Rechercher des branches...",
+      "noBranchesFound": "Aucune branche trouvée",
       "helpText": "Remplacez la branche à partir de laquelle le worktree de cette tâche sera créé. Laissez vide pour utiliser la branche par défaut configurée du projet.",
       "useWorktreeLabel": "Utiliser un espace de travail isolé (recommandé)",
       "useWorktreeDescription": "Crée les changements dans un worktree git séparé pour une révision sécurisée avant la fusion. Désactivez pour travailler directement dans votre projet (plus rapide mais risqué)."


### PR DESCRIPTION
Replace the plain branch selector dropdown in TaskCreationWizard's Git Options with the existing searchable Combobox component. Currently, users must manually scroll through potentially many branches to find the one they want. The codebase already has a Combobox component with built-in search functionality that can be reused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable branch selection to the Git base-branch picker in the task creation workflow, enabling users to quickly find and select branches by typing instead of scrolling through a full list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->