### PR TITLE
fix(frontend): remove TOCTOU race condition in spec number lock

### DIFF
--- a/apps/frontend/src/main/utils/spec-number-lock.ts
+++ b/apps/frontend/src/main/utils/spec-number-lock.ts
@@ -52,15 +52,13 @@ export class SpecNumberLock {
 
     while (true) {
       try {
-        // Try to create lock file exclusively using 'wx' flag
-        // This will throw if file already exists
-        if (!existsSync(this.lockFile)) {
-          writeFileSync(this.lockFile, String(process.pid), { flag: 'wx' });
-          this.acquired = true;
-          return;
-        }
+        // Try to create lock file exclusively using 'wx' flag (atomic operation)
+        // This will throw EEXIST if file already exists - no pre-check needed
+        writeFileSync(this.lockFile, String(process.pid), { flag: 'wx' });
+        this.acquired = true;
+        return;
       } catch (error: unknown) {
-        // EEXIST means file was created by another process between check and create
+        // EEXIST means lock is held by another process
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
           throw error;
         }


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes a Time-Of-Check-To-Time-Of-Use (TOCTOU) race condition in the frontend spec number lock mechanism. The redundant `existsSync()` check before `writeFileSync(..., { flag: 'wx' })` allowed concurrent processes to both pass the check and attempt to create the lock file, leading to duplicate spec numbers (e.g., multiple `006-*` directories).

## Related Issue

N/A - Discovered during investigation of spec creation failures

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

## Commit Message Format

`fix(frontend): remove TOCTOU race condition in spec number lock`

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

- [x] **Windows tested** (either on Windows or via CI)
- [ ] **macOS tested** (either on macOS or via CI)
- [ ] **Linux tested** (CI covers this)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

## CI/Testing Requirements

- [ ] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

## Screenshots

N/A - No UI changes

## Feature Toggle

- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

## Root Cause Analysis

The original code had a TOCTOU vulnerability:

```typescript
// BEFORE - Race condition between check and create
if (!existsSync(this.lockFile)) {          // Process A & B both pass this check
  writeFileSync(this.lockFile, ..., { flag: 'wx' });  // Both try to create
}
```

The fix removes the redundant check and relies solely on the atomic `flag: 'wx'`:

```typescript
// AFTER - Atomic operation, no race condition
writeFileSync(this.lockFile, String(process.pid), { flag: 'wx' });
// Throws EEXIST if file exists - handled in catch block
```

This matches the Python backend's correct implementation using `os.O_CREAT | os.O_EXCL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file locking mechanism to use atomic operations for enhanced reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->