### PR TITLE
fix(terminal): rename Claude terminals only once on initial message

### DIFF
--- a/apps/frontend/src/renderer/components/settings/DevToolsSettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/DevToolsSettings.tsx
@@ -365,6 +365,30 @@ export function DevToolsSettings({ settings, onSettingsChange }: DevToolsSetting
           )}
         </div>
 
+        {/* Auto-name Claude Terminals Toggle */}
+        <div className="space-y-3 pt-2 border-t border-border">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="auto-name-claude-terminals" className="text-sm font-medium">
+                {t('devtools.autoNameClaude.label', 'Auto-name Claude terminals')}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t('devtools.autoNameClaude.description', 'Use AI to generate a descriptive name for Claude terminals based on your first message')}
+              </p>
+            </div>
+            <Switch
+              id="auto-name-claude-terminals"
+              checked={settings.autoNameClaudeTerminals ?? true}
+              onCheckedChange={(checked) => {
+                onSettingsChange({
+                  ...settings,
+                  autoNameClaudeTerminals: checked
+                });
+              }}
+            />
+          </div>
+        </div>
+
         {/* YOLO Mode Toggle */}
         <div className="space-y-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-4">
           <div className="flex items-center justify-between">

--- a/apps/frontend/src/renderer/components/settings/DevToolsSettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/DevToolsSettings.tsx
@@ -376,6 +376,7 @@ export function DevToolsSettings({ settings, onSettingsChange }: DevToolsSetting
                 {t('devtools.autoNameClaude.description', 'Use AI to generate a descriptive name for Claude terminals based on your first message')}
               </p>
             </div>
+            {/* Fallback to true for existing users who don't have this setting in persisted config */}
             <Switch
               id="auto-name-claude-terminals"
               checked={settings.autoNameClaudeTerminals ?? true}

--- a/apps/frontend/src/renderer/components/terminal/useAutoNaming.ts
+++ b/apps/frontend/src/renderer/components/terminal/useAutoNaming.ts
@@ -11,51 +11,72 @@ export function useAutoNaming({ terminalId, cwd }: UseAutoNamingOptions) {
   const lastCommandRef = useRef<string>('');
   const autoNameTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const autoNameTerminals = useSettingsStore((state) => state.settings.autoNameTerminals);
+  const autoNameClaudeTerminals = useSettingsStore((state) => state.settings.autoNameClaudeTerminals);
   const terminal = useTerminalStore((state) => state.terminals.find((t) => t.id === terminalId));
   const updateTerminal = useTerminalStore((state) => state.updateTerminal);
+  const setClaudeNamedOnce = useTerminalStore((state) => state.setClaudeNamedOnce);
 
   const triggerAutoNaming = useCallback(async () => {
-    if (!autoNameTerminals || terminal?.isClaudeMode || !lastCommandRef.current.trim()) {
+    // Check if we have a command to base the name on
+    if (!lastCommandRef.current.trim()) {
       return;
     }
 
-    const command = lastCommandRef.current.trim();
-    const commandLower = command.toLowerCase();
-    const firstWord = commandLower.split(/\s+/)[0];
+    // Handle Claude mode vs regular terminal mode
+    if (terminal?.isClaudeMode) {
+      // In Claude mode: only rename if autoNameClaudeTerminals is enabled AND we haven't named yet
+      if (!autoNameClaudeTerminals || terminal?.claudeNamedOnce) {
+        return;
+      }
+    } else {
+      // Regular terminal mode: use the standard autoNameTerminals setting
+      if (!autoNameTerminals) {
+        return;
+      }
+    }
 
-    // Skip very short commands
+    const command = lastCommandRef.current.trim();
+
+    // Skip very short commands/messages
     if (command.length < 3) {
       return;
     }
 
-    // Skip common shell/navigation commands that don't represent meaningful work.
-    // These commands are too generic to produce useful terminal names - they don't indicate
-    // a specific task or purpose. For example, "git" could be any git operation,
-    // "npm" could be install, run, or test. Meaningful names come from project-specific
-    // commands like "npm run build:prod" or application-specific scripts.
-    const skipCommands = [
-      // Navigation & file listing
-      'ls', 'cd', 'll', 'la', 'pwd', 'dir', 'tree',
-      // Shell control
-      'exit', 'clear', 'cls', 'reset', 'history',
-      // Claude CLI - naming should come from the task description inside Claude, not the launch command
-      'claude',
-      // Common dev tools that are too generic
-      'git', 'npm', 'yarn', 'pnpm', 'node', 'python', 'pip', 'cargo', 'go',
-      'docker', 'kubectl', 'make', 'cmake',
-      // Package managers
-      'brew', 'apt', 'yum', 'pacman', 'choco', 'scoop', 'winget',
-      // Editors
-      'vim', 'nvim', 'nano', 'code', 'cursor',
-      // System commands
-      'cat', 'head', 'tail', 'less', 'more', 'grep', 'find', 'which', 'where',
-      'echo', 'env', 'export', 'set', 'unset', 'alias', 'source',
-      'chmod', 'chown', 'mkdir', 'rmdir', 'rm', 'cp', 'mv', 'touch',
-      'man', 'help', 'whoami', 'hostname', 'date', 'time', 'top', 'htop', 'ps',
-    ];
+    // In Claude mode, messages are natural language prompts, not shell commands
+    // Skip the shell command filtering since we want to name based on the first prompt
+    if (!terminal?.isClaudeMode) {
+      const commandLower = command.toLowerCase();
+      const firstWord = commandLower.split(/\s+/)[0];
 
-    if (skipCommands.includes(firstWord)) {
-      return;
+      // Skip common shell/navigation commands that don't represent meaningful work.
+      // These commands are too generic to produce useful terminal names - they don't indicate
+      // a specific task or purpose. For example, "git" could be any git operation,
+      // "npm" could be install, run, or test. Meaningful names come from project-specific
+      // commands like "npm run build:prod" or application-specific scripts.
+      const skipCommands = [
+        // Navigation & file listing
+        'ls', 'cd', 'll', 'la', 'pwd', 'dir', 'tree',
+        // Shell control
+        'exit', 'clear', 'cls', 'reset', 'history',
+        // Claude CLI - naming should come from the task description inside Claude, not the launch command
+        'claude',
+        // Common dev tools that are too generic
+        'git', 'npm', 'yarn', 'pnpm', 'node', 'python', 'pip', 'cargo', 'go',
+        'docker', 'kubectl', 'make', 'cmake',
+        // Package managers
+        'brew', 'apt', 'yum', 'pacman', 'choco', 'scoop', 'winget',
+        // Editors
+        'vim', 'nvim', 'nano', 'code', 'cursor',
+        // System commands
+        'cat', 'head', 'tail', 'less', 'more', 'grep', 'find', 'which', 'where',
+        'echo', 'env', 'export', 'set', 'unset', 'alias', 'source',
+        'chmod', 'chown', 'mkdir', 'rmdir', 'rm', 'cp', 'mv', 'touch',
+        'man', 'help', 'whoami', 'hostname', 'date', 'time', 'top', 'htop', 'ps',
+      ];
+
+      if (skipCommands.includes(firstWord)) {
+        return;
+      }
     }
 
     try {
@@ -64,11 +85,16 @@ export function useAutoNaming({ terminalId, cwd }: UseAutoNamingOptions) {
         updateTerminal(terminalId, { title: result.data });
         // Sync to main process so title persists across hot reloads
         window.electronAPI.setTerminalTitle(terminalId, result.data);
+
+        // Mark Claude terminal as named once to prevent repeated renames
+        if (terminal?.isClaudeMode) {
+          setClaudeNamedOnce(terminalId, true);
+        }
       }
     } catch (error) {
       console.warn('[Terminal] Auto-naming failed:', error);
     }
-  }, [autoNameTerminals, terminal?.isClaudeMode, terminal?.cwd, cwd, terminalId, updateTerminal]);
+  }, [autoNameTerminals, autoNameClaudeTerminals, terminal?.isClaudeMode, terminal?.claudeNamedOnce, terminal?.cwd, cwd, terminalId, updateTerminal, setClaudeNamedOnce]);
 
   const handleCommandEnter = useCallback((command: string) => {
     lastCommandRef.current = command;

--- a/apps/frontend/src/renderer/components/terminal/useAutoNaming.ts
+++ b/apps/frontend/src/renderer/components/terminal/useAutoNaming.ts
@@ -87,7 +87,9 @@ export function useAutoNaming({ terminalId, cwd }: UseAutoNamingOptions) {
         window.electronAPI.setTerminalTitle(terminalId, result.data);
 
         // Mark Claude terminal as named once to prevent repeated renames
-        if (terminal?.isClaudeMode) {
+        // Re-fetch terminal state after async operation to avoid stale closure
+        const currentTerminal = useTerminalStore.getState().terminals.find((t) => t.id === terminalId);
+        if (currentTerminal?.isClaudeMode) {
           setClaudeNamedOnce(terminalId, true);
         }
       }

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -94,6 +94,7 @@ export interface Terminal {
   isClaudeBusy?: boolean;  // Whether Claude Code is actively processing (for visual indicator)
   pendingClaudeResume?: boolean;  // Whether this terminal has a pending Claude resume (deferred until tab activated)
   displayOrder?: number;  // Display order for tab persistence (lower = further left)
+  claudeNamedOnce?: boolean;  // Whether this Claude terminal has been auto-named based on initial message (prevents repeated naming)
 }
 
 interface TerminalLayout {
@@ -126,6 +127,7 @@ interface TerminalState {
   setWorktreeConfig: (id: string, config: TerminalWorktreeConfig | undefined) => void;
   setClaudeBusy: (id: string, isBusy: boolean) => void;
   setPendingClaudeResume: (id: string, pending: boolean) => void;
+  setClaudeNamedOnce: (id: string, named: boolean) => void;
   clearAllTerminals: () => void;
   setHasRestoredSessions: (value: boolean) => void;
   reorderTerminals: (activeId: string, overId: string) => void;
@@ -316,8 +318,9 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
               ...t,
               isClaudeMode,
               status: isClaudeMode ? 'claude-active' : 'running',
-              // Reset busy state when leaving Claude mode
-              isClaudeBusy: isClaudeMode ? t.isClaudeBusy : undefined
+              // Reset busy state and naming flag when leaving Claude mode
+              isClaudeBusy: isClaudeMode ? t.isClaudeBusy : undefined,
+              claudeNamedOnce: isClaudeMode ? t.claudeNamedOnce : undefined
             }
           : t
       ),
@@ -360,6 +363,14 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     set((state) => ({
       terminals: state.terminals.map((t) =>
         t.id === id ? { ...t, pendingClaudeResume: pending } : t
+      ),
+    }));
+  },
+
+  setClaudeNamedOnce: (id: string, named: boolean) => {
+    set((state) => ({
+      terminals: state.terminals.map((t) =>
+        t.id === id ? { ...t, claudeNamedOnce: named } : t
       ),
     }));
   },

--- a/apps/frontend/src/shared/constants/config.ts
+++ b/apps/frontend/src/shared/constants/config.ts
@@ -57,7 +57,9 @@ export const DEFAULT_APP_SETTINGS = {
   // Language preference (default to English)
   language: 'en' as const,
   // Anonymous error reporting (Sentry) - enabled by default to help improve the app
-  sentryEnabled: true
+  sentryEnabled: true,
+  // Auto-name Claude terminals based on initial message (enabled by default)
+  autoNameClaudeTerminals: true
 };
 
 // ============================================

--- a/apps/frontend/src/shared/i18n/locales/en/settings.json
+++ b/apps/frontend/src/shared/i18n/locales/en/settings.json
@@ -262,6 +262,10 @@
     "notInstalled": "Not installed",
     "detectedSummary": "Detected on your system:",
     "noToolsDetected": "No additional tools detected (VS Code and system terminal will be used)",
+    "autoNameClaude": {
+      "label": "Auto-name Claude terminals",
+      "description": "Use AI to generate a descriptive name for Claude terminals based on your first message"
+    },
     "yoloMode": {
       "label": "YOLO Mode",
       "description": "Start Claude with --dangerously-skip-permissions flag, bypassing all safety prompts. Use with extreme caution.",

--- a/apps/frontend/src/shared/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/settings.json
@@ -262,6 +262,10 @@
     "notInstalled": "Non installé",
     "detectedSummary": "Détecté sur votre système :",
     "noToolsDetected": "Aucun outil supplémentaire détecté (VS Code et le terminal système seront utilisés)",
+    "autoNameClaude": {
+      "label": "Nommer automatiquement les terminaux Claude",
+      "description": "Utiliser l'IA pour générer un nom descriptif pour les terminaux Claude basé sur votre premier message"
+    },
     "yoloMode": {
       "label": "Mode YOLO",
       "description": "Démarrer Claude avec le flag --dangerously-skip-permissions, contournant toutes les invites de sécurité. À utiliser avec une extrême prudence.",

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -283,6 +283,8 @@ export interface AppSettings {
   dangerouslySkipPermissions?: boolean;
   // Anonymous error reporting (Sentry) - enabled by default to help improve the app
   sentryEnabled?: boolean;
+  // Auto-name Claude terminals based on initial message (only triggers once per session)
+  autoNameClaudeTerminals?: boolean;
 }
 
 // Auto-Claude Source Environment Configuration (for auto-claude repo .env)


### PR DESCRIPTION
## Summary

- Add `autoNameClaudeTerminals` setting to control whether Claude terminals should be auto-named based on first message
- Add `claudeNamedOnce` flag to terminal store to prevent repeated renames on subsequent messages
- Update `useAutoNaming` hook to only trigger rename once in Claude mode
- Add toggle to Settings → Developer Tools section

**Fixes:** Terminal renaming every time a message is sent to Claude instead of just once on initial message.

## Changes

| File | Description |
|------|-------------|
| `settings.ts` | Add `autoNameClaudeTerminals?: boolean` type |
| `config.ts` | Add default value `autoNameClaudeTerminals: true` |
| `terminal-store.ts` | Add `claudeNamedOnce` flag and `setClaudeNamedOnce` action |
| `useAutoNaming.ts` | Refactor to only rename once in Claude mode |
| `DevToolsSettings.tsx` | Add UI toggle for the setting |
| `en/settings.json` | Add English translations |
| `fr/settings.json` | Add French translations |

## Test plan

- [ ] Start Claude in a terminal with default name (e.g., "Terminal 1")
- [ ] Send first message to Claude - terminal should be renamed based on message content
- [ ] Send additional messages - terminal name should NOT change
- [ ] Exit Claude and re-invoke - terminal can be renamed again on next first message
- [ ] Disable setting in Developer Tools - terminal should not auto-rename at all
- [ ] Verify translations work in both English and French

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude terminals can be automatically named from the initial AI prompt (once per session). Toggle available in Developer Tools (enabled by default).

* **Bug Fixes**
  * The Developer Tools UI currently shows the auto-name toggle twice in some places — duplicate display will be fixed.

* **Localization**
  * English and French labels/descriptions added for the new setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->