### PR TITLE
fix(windows): use SDK bundled Claude CLI for Windows packaged apps

### DIFF
--- a/apps/backend/core/auth.py
+++ b/apps/backend/core/auth.py
@@ -58,6 +58,8 @@ SDK_ENV_VARS = [
     "API_TIMEOUT_MS",
     # Windows-specific: Git Bash path for Claude Code CLI
     "CLAUDE_CODE_GIT_BASH_PATH",
+    # Claude CLI path override (allows frontend to pass detected CLI path to SDK)
+    "CLAUDE_CLI_PATH",
 ]
 
 

--- a/apps/frontend/scripts/download-python.cjs
+++ b/apps/frontend/scripts/download-python.cjs
@@ -105,7 +105,10 @@ const STRIP_PATTERNS = {
   // Format: 'package_name/subpath' - removes the entire subpath
   packagePaths: [
     'googleapiclient/discovery_cache/documents',  // Cached Google API discovery docs (92MB!)
-    'claude_agent_sdk/_bundled',                  // Bundled Claude CLI (224MB!) - users have it installed separately
+    // NOTE: claude_agent_sdk/_bundled is NO LONGER excluded.
+    // On Windows, the system-installed Claude CLI is claude.cmd (a batch script),
+    // which cannot be executed by anyio.open_process() / asyncio.create_subprocess_exec().
+    // The SDK's bundled claude.exe is a proper executable and works correctly.
   ],
   // Packages that should NEVER be bundled (too large, specialized)
   // If these appear in dependencies, warn and skip

--- a/apps/frontend/src/main/agent/agent-process.test.ts
+++ b/apps/frontend/src/main/agent/agent-process.test.ts
@@ -123,6 +123,8 @@ vi.mock('../cli-tool-manager', () => ({
     }
     return { found: false, path: undefined, source: 'user-config', message: `${tool} not found` };
   }),
+  // getClaudeCliPathForSdk returns null by default (simulates not found or .cmd file on Windows)
+  getClaudeCliPathForSdk: vi.fn(() => null),
   deriveGitBashPath: vi.fn(() => null),
   clearCache: vi.fn()
 }));
@@ -159,7 +161,7 @@ import { AgentEvents } from './agent-events';
 import * as profileService from '../services/profile';
 import * as rateLimitDetector from '../rate-limit-detector';
 import { pythonEnvManager } from '../python-env-manager';
-import { getToolInfo } from '../cli-tool-manager';
+import { getToolInfo, getClaudeCliPathForSdk } from '../cli-tool-manager';
 
 describe('AgentProcessManager - API Profile Env Injection (Story 2.3)', () => {
   let processManager: AgentProcessManager;
@@ -754,11 +756,11 @@ describe('AgentProcessManager - API Profile Env Injection (Story 2.3)', () => {
     });
 
     it('should set GITHUB_CLI_PATH with same precedence as CLAUDE_CLI_PATH', async () => {
-      // Mock both Claude CLI and gh CLI as found
+      // Mock Claude CLI via getClaudeCliPathForSdk (returns path directly, not .cmd file)
+      vi.mocked(getClaudeCliPathForSdk).mockReturnValue('/opt/homebrew/bin/claude');
+
+      // Mock gh CLI via getToolInfo (gh still uses standard detection)
       vi.mocked(getToolInfo).mockImplementation((tool: string) => {
-        if (tool === 'claude') {
-          return { found: true, path: '/opt/homebrew/bin/claude', source: 'homebrew', message: 'Claude CLI found via Homebrew' };
-        }
         if (tool === 'gh') {
           return { found: true, path: '/opt/homebrew/bin/gh', source: 'homebrew', message: 'gh CLI found via Homebrew' };
         }

--- a/apps/frontend/src/main/python-detector.ts
+++ b/apps/frontend/src/main/python-detector.ts
@@ -291,6 +291,12 @@ const ALLOWED_PATH_PATTERNS: RegExp[] = [
   /^.*\/miniconda\d*\/bin\/python\d*(\.\d+)?$/,
   /^.*\/anaconda\d*\/envs\/[^/]+\/bin\/python\d*(\.\d+)?$/,
   /^.*\/miniconda\d*\/envs\/[^/]+\/bin\/python\d*(\.\d+)?$/,
+  // Bundled Python in packaged Electron apps (macOS/Linux)
+  // Matches paths like: /path/to/app/resources/python/bin/python3
+  /^.*\/resources\/python\/bin\/python\d*(\.\d+)?$/,
+  // Bundled Python in packaged Electron apps (Windows)
+  // Matches paths like: C:\path\to\app\resources\python\python.exe
+  /^.*\\resources\\python\\python\.exe$/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Fix Windows packaged app failure when invoking Claude agents
- The root cause: Windows `claude.cmd` cannot be executed by `anyio.open_process()` / `asyncio.create_subprocess_exec()` (batch scripts need shell execution)
- Solution: Use the SDK bundled `claude.exe` which is a proper Windows executable

## Changes

### Core SDK Integration (4 files)

1. **Stop excluding SDK bundled CLI** (`download-python.cjs`)
   - Removed `claude_agent_sdk/_bundled` from exclusion list
   - Bundled `claude.exe` now included in packaged app (~224MB)

2. **Add Windows .cmd detection** (`cli-tool-manager.ts`)
   - New `getClaudeCliPathForSdk()` returns `null` for `.cmd` files on Windows
   - When `cli_path` is `null`, SDK uses its bundled `claude.exe`
   - Added async version `getClaudeCliPathForSdkAsync()`

3. **Add SDK env var passthrough** (`auth.py`)
   - Added `CLAUDE_CLI_PATH` to `SDK_ENV_VARS` list

4. **Add bundled Python paths** (`python-detector.ts`)
   - Added allowlist patterns for bundled Python in packaged apps

### Additional Fixes (3 files)

5. **Update agent task execution** (`agent-process.ts`)
   - Use `getClaudeCliPathForSdk()` for Claude CLI detection
   - Only sets `CLAUDE_CLI_PATH` env var if path is not `.cmd`
   - On Windows with `.cmd`, lets SDK use bundled CLI instead

6. **Fix changelog generation** (`changelog/formatter.ts`)
   - Add `shell=True` to Python subprocess when Claude path is `.cmd/.bat`
   - Required because batch scripts need `cmd.exe` to execute

7. **Fix version suggestion** (`changelog/version-suggester.ts`)
   - Same `shell=True` fix for `.cmd/.bat` files
   - Also fixed missing path escaping for Windows backslashes

### Test Updates

8. **Update agent-process tests** (`agent-process.test.ts`)
   - Add mock for new `getClaudeCliPathForSdk` function
   - Update test expectations for Claude CLI detection changes

## Test plan

- [x] TypeScript type checking passes
- [x] All frontend tests pass (2082 tests)
- [ ] Test Windows packaged app can invoke Claude agents
- [ ] Test Windows changelog generation works
- [ ] Test macOS/Linux still work (should use system CLI as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Claude CLI detection and integration for SDK usage
  * Added Windows batch file (.cmd/.bat) support for subprocess execution
  * Extended Python validation to recognize bundled executables in packaged applications
  * Enabled environment variable pass-through for detected CLI paths

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->