### PR TITLE
hotfix: disable npmRebuild for electron-builder workspace compatibility

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -140,6 +140,7 @@
   "build": {
     "appId": "com.autoclaude.ui",
     "productName": "Auto-Claude",
+    "npmRebuild": false,
     "artifactName": "${productName}-${version}-${platform}-${arch}.${ext}",
     "publish": [
       {


### PR DESCRIPTION
## Summary

Fixes macOS (Intel & Silicon) release build failures by disabling electron-builder's native module rebuild step.

## Root Cause

electron-builder's `@electron/rebuild` cannot properly handle symlinked `node_modules` directories in npm workspace setups. Even with a symlink from `apps/frontend/node_modules` → `../../node_modules`, it fails with:
```
ENOENT: no such file or directory, stat 'apps/frontend/node_modules'
```

## Solution

Set `npmRebuild: false` in electron-builder config. This works because:
1. `stageRuntimePackages()` already manually copies `@lydell/node-pty` to `out/main/node_modules`
2. `@lydell/node-pty` uses **prebuilt binaries** - no rebuild needed
3. This bypasses the problematic `@electron/rebuild` phase entirely

## Changes
- `apps/frontend/package.json`: Added `"npmRebuild": false` to build config

## Testing
This should fix the failing release builds for:
- ✅ macOS Intel (x64)
- ✅ macOS Silicon (arm64)
- ✅ Windows (if affected)

**IMPORTANT: Merge with "Create a merge commit" - do NOT squash.**

After merge, we will recreate the v2.7.5 tag to trigger the release workflow.

---

🤖 Generated with [Claude Code](https://claude.ai/code)