### PR TITLE
Fix human_review status bugs (#1149, #509)

### DIFF
--- a/apps/backend/implementation_plan/plan.py
+++ b/apps/backend/implementation_plan/plan.py
@@ -167,7 +167,17 @@ class ImplementationPlan:
         all_subtasks = [s for p in self.phases for s in p.subtasks]
 
         if not all_subtasks:
-            # No subtasks yet - stay in backlog/pending
+            # No subtasks yet - check if this is a failed planning state
+            # Fix for #1149: If status is human_review but no phases/subtasks exist,
+            # planning crashed - reset to backlog instead of preserving invalid state
+            if self.status == "human_review" and not self.phases:
+                # Planning failed - don't show as human_review with Resume button
+                self.status = "backlog"
+                self.planStatus = "pending"
+                self.recoveryNote = "Planning phase failed - no implementation plan created"
+                return
+
+            # Normal case: No subtasks yet - stay in backlog/pending
             if not self.status:
                 self.status = "backlog"
             if not self.planStatus:


### PR DESCRIPTION
## Summary

This PR fixes two related bugs where tasks incorrectly show "Needs Resume" or get stuck in `human_review` status:

### Fix 1: Planning crash leaves task in human_review (#1149)

When planning crashes and leaves no phases/subtasks, `update_status_from_subtasks()` was preserving the `human_review` status even though there was no valid plan. This caused tasks to show "Incomplete + Needs Resume" in the UI with 0 subtasks.

**Solution:** Check if status is `human_review` but phases list is empty - this indicates planning failed. Reset to `backlog` with a recovery note instead.

**File:** `apps/backend/implementation_plan/plan.py`

### Fix 2: Task stuck in human_review after approval (#509)

After a user approves a plan, clicking "Resume" would not start execution because there was no code to transition the status from `human_review` to `in_progress` when continuing a build. The task would remain stuck forever.

**Solution:** In the "continuing build" path of `coder.py`, check if the plan is in `human_review` status and if so, validate the approval and transition to `in_progress` before starting execution.

**File:** `apps/backend/agents/coder.py`

## Test plan

- [ ] Create a task and interrupt planning phase mid-way - verify task goes to Backlog (not Human Review)
- [ ] Create and approve a plan, then resume - verify execution starts (not stuck in Human Review)
- [ ] Normal flow still works: plan → approve → execute → complete

## Related Issues

Fixes #1149
Fixes #509
Related to #457, #585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build resumption now verifies approval before continuing; invalid approvals require re-approval.
  * Planning can recover from a stuck/crashed state by resetting affected plans back to backlog.
  * When a task fails with no subtasks, status now resets to backlog (with a warning) instead of moving to human review.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->