### PR TITLE
auto-claude: 144-add-markdown-support-to-update-changelog

### DIFF
--- a/apps/frontend/src/main/app-updater.ts
+++ b/apps/frontend/src/main/app-updater.ts
@@ -62,8 +62,13 @@ function formatReleaseNotes(releaseNotes: UpdateInfo['releaseNotes']): string | 
   // It's an array of ReleaseNoteInfo objects
   // Format: [{ version: "1.0.0", note: "changes..." }, ...]
   if (Array.isArray(releaseNotes)) {
+    // Return undefined for empty arrays for consistency with null/undefined handling
+    if (releaseNotes.length === 0) {
+      return undefined;
+    }
+
     const formattedNotes = releaseNotes
-      .filter(item => item.note) // Only include entries with notes
+      .filter(item => item.note) // Filter out entries with null/undefined notes
       .map(item => {
         // Each item has version and note properties
         const versionHeader = item.version ? `## ${item.version}\n` : '';


### PR DESCRIPTION
Fix release notes/changelog markdown rendering in the Update settings tab by properly converting `releaseNotes` from electron-updater format to markdown string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release notes handling to consistently treat empty release-note lists the same as missing notes, avoiding unnecessary processing and preventing empty sections from being shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->