### PR TITLE
fix(auth): check .credentials.json for Linux profile authentication

### DIFF
--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -88,13 +88,45 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
     }
   }
 
+  // Check for .credentials.json with OAuth tokens (Linux CLI storage)
+  // On Linux, the Claude CLI stores OAuth tokens in this file
+  const credentialsJsonPath = join(configDir, '.credentials.json');
+  if (existsSync(credentialsJsonPath)) {
+    try {
+      const content = readFileSync(credentialsJsonPath, 'utf-8');
+      const data = JSON.parse(content);
+      // Validate OAuth data structure
+      // Check for claudeAiOauth (primary Linux structure)
+      if (data && typeof data === 'object' && data.claudeAiOauth) {
+        // Validate that claudeAiOauth contains actual auth data
+        const hasValidAuth = data.claudeAiOauth.accessToken ||
+                             data.claudeAiOauth.refreshToken ||
+                             data.claudeAiOauth.email ||
+                             data.claudeAiOauth.emailAddress;
+        if (hasValidAuth) {
+          return true;
+        }
+      }
+      // Check for oauthAccount (alternative structure)
+      if (data && typeof data === 'object' && data.oauthAccount?.emailAddress) {
+        return true;
+      }
+      // Check for generic token fields (legacy formats)
+      if (data && typeof data === 'object' && (data.accessToken || data.refreshToken || data.token)) {
+        return true;
+      }
+    } catch (error) {
+      // Log parse errors for debugging, but fall through to legacy checks
+      console.warn(`[profile-utils] Failed to read or parse ${credentialsJsonPath}:`, error);
+    }
+  }
+
   // Legacy: Claude stores auth in .claude/credentials or similar files
   // Check for common auth indicators
   const possibleAuthFiles = [
     join(configDir, 'credentials'),
     join(configDir, 'credentials.json'),
     join(configDir, '.credentials'),
-    join(configDir, '.credentials.json'),  // Linux: Claude CLI stores OAuth tokens here
     join(configDir, 'settings.json'),  // Often contains auth tokens
   ];
 

--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -94,6 +94,7 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
     join(configDir, 'credentials'),
     join(configDir, 'credentials.json'),
     join(configDir, '.credentials'),
+    join(configDir, '.credentials.json'),  // Linux: Claude CLI stores OAuth tokens here
     join(configDir, 'settings.json'),  // Often contains auth tokens
   ];
 


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes a Linux-specific bug where custom Claude profiles never show as authenticated in the UI, even after completing OAuth successfully. 

On Linux, the Claude CLI stores OAuth tokens in `.credentials.json` within the profile's config directory. The `isProfileAuthenticated()` function was not checking this file, causing it to always return `false` for custom profiles on Linux. This meant the UI would show "Needs Auth" indefinitely and would not persist the authentication status.

## Related Issue

Closes #[GitHub issue number] (ACS-388)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

## Commit Message Format

Follow conventional commits: `<type>: <subject>`

**Types:** feat, fix, docs, style, refactor, test

**Example:** `feat: add user authentication system`

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally) - **1 line changed**
- [ ] **(Python only)** All file operations specify `encoding="utf-8"` for text files

## Platform Testing Checklist

**CRITICAL:** This project supports Windows, macOS, and Linux. Platform-specific bugs are a common source of breakage.

- [ ] **Windows tested** (N/A - this fix is Linux-specific, harmless on other platforms)
- [ ] **macOS tested** (N/A - this fix is Linux-specific, harmless on other platforms)
- [x] **Linux tested** (This is the specific platform being fixed)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks (N/A - using feature detection via `existsSync()`)
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [x] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [ ] New features include test coverage (N/A - bug fix)
- [ ] Bug fixes include regression tests (N/A - existing test infrastructure validates the behavior)

## Screenshots

<!-- Required for UI changes. Delete if not applicable. -->

| Before | After |
|--------|-------|
| Custom profiles on Linux always showed "Needs Auth" | Custom profiles on Linux now correctly show authenticated status |

## Feature Toggle

<!-- If feature is incomplete or experimental, how is it hidden from users? -->
<!-- This ensures incomplete work can be merged without affecting production. -->

- [ ] Behind localStorage flag: `use_feature_name`
- [ ] Behind settings toggle
- [ ] Behind environment variable/config
- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

<!-- Does this PR introduce breaking changes? If yes, describe what breaks and migration steps. -->
<!-- Delete this section if not applicable. -->

**Breaking:** No

**Details:**
This is a purely additive change - it adds one more file path to check when determining authentication status. The change:
- Uses existing `existsSync()` pattern (safe on all platforms)
- Does not modify any existing behavior
- Cannot break existing functionality
- Is backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced profile authentication detection to recognize additional credential file formats, improving compatibility with various authentication configuration methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->