### PR TITLE
fix: resolve flaky subprocess-spawn test on Windows CI (ACS-392)

### DIFF
--- a/apps/frontend/src/__tests__/integration/subprocess-spawn.test.ts
+++ b/apps/frontend/src/__tests__/integration/subprocess-spawn.test.ts
@@ -394,6 +394,9 @@ describe('Subprocess Spawn Integration', () => {
         expect(manager.getRunningTasks()).toHaveLength(2);
       }, { timeout: 5000 });
 
+      // Wait for spawn to complete (ensures exit handlers are attached)
+      await new Promise(resolve => setImmediate(resolve));
+
       // Both tasks share the same mock process, so emit exit once triggers both handlers
       mockProcess.emit('exit', 0);
 

--- a/apps/frontend/src/main/agent/agent-process.ts
+++ b/apps/frontend/src/main/agent/agent-process.ts
@@ -569,6 +569,11 @@ export class AgentProcessManager {
     // If so, terminate the newly created process immediately to prevent orphaned processes.
     // Note: wasSpawnKilled() is checked AFTER updateProcess() because killProcess()
     // marks the spawn as killed before deleting the tracking entry.
+    //
+    // CRITICAL: The `?? spawnId` fallback is essential here because if killProcess()
+    // was called during the async setup window, the taskId entry may have been deleted
+    // from the process map. In that case, getProcess(taskId) returns undefined, so we
+    // fall back to the local spawnId variable to check if this specific spawn was killed.
     const currentSpawnId = this.state.getProcess(taskId)?.spawnId ?? spawnId;
     if (this.state.wasSpawnKilled(currentSpawnId)) {
       console.log(`[AgentProcess] Task ${taskId} was killed during spawn setup. Terminating newly created process.`);

--- a/apps/frontend/src/main/agent/agent-state.ts
+++ b/apps/frontend/src/main/agent/agent-state.ts
@@ -86,6 +86,10 @@ export class AgentState {
 
   /**
    * Update a process's properties (e.g., after spawn completes)
+   *
+   * Note: Silently ignores updates if taskId doesn't exist. This is intentional for
+   * race condition handling in spawnProcess() - if a task is killed during async setup,
+   * the tracking entry is deleted before spawn() completes, and we don't want to fail here.
    */
   updateProcess(taskId: string, updates: Partial<AgentProcess>): void {
     const existing = this.processes.get(taskId);

--- a/apps/frontend/src/main/agent/agent-state.ts
+++ b/apps/frontend/src/main/agent/agent-state.ts
@@ -85,6 +85,16 @@ export class AgentState {
   }
 
   /**
+   * Update a process's properties (e.g., after spawn completes)
+   */
+  updateProcess(taskId: string, updates: Partial<AgentProcess>): void {
+    const existing = this.processes.get(taskId);
+    if (existing) {
+      this.processes.set(taskId, { ...existing, ...updates });
+    }
+  }
+
+  /**
    * Get all processes
    */
   getAllProcesses(): Map<string, AgentProcess> {

--- a/apps/frontend/src/main/agent/types.ts
+++ b/apps/frontend/src/main/agent/types.ts
@@ -10,7 +10,7 @@ export type QueueProcessType = 'ideation' | 'roadmap';
 
 export interface AgentProcess {
   taskId: string;
-  process: ChildProcess;
+  process: ChildProcess | null; // null during async spawn setup before ChildProcess is created
   startedAt: Date;
   projectPath?: string; // For ideation processes to load session on completion
   spawnId: number; // Unique ID to identify this specific spawn


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes flaky test `subprocess-spawn.test.ts > should track running tasks` that was failing intermittently on Windows CI. The root cause was a race condition where `vi.waitFor()` would timeout before tasks were added to tracking, because `state.addProcess()` was called AFTER async operations (profile init, Python env ready, API profile env) that could be slower on Windows CI.

**Solution:** Move `state.addProcess()` to execute immediately at `spawnProcess()` start, before async operations complete. The process is initially tracked with `process: null` and updated after spawn completes.

**Changes:**
- Move `state.addProcess()` to execute immediately before async operations
- Update `AgentProcess.process` type to `ChildProcess | null` to handle initialization state
- Add `updateProcess()` method to set the actual `ChildProcess` after spawn()
- Add null checks in `killProcess()` and `killAllProcesses()` for async setup window
- Add `setImmediate()` wait in test to ensure exit handlers are attached

## Related Issue

Closes #1391
Refs: ACS-392

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

## Commit Message Format

Follow conventional commits: `<type>: <subject>`

**Types:** feat, fix, docs, style, refactor, test, chore

**Example:** `feat: add user authentication system`

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)
- [ ] **(Python only)** All file operations specify `encoding="utf-8"` for text files

## Platform Testing Checklist

**CRITICAL:** This project supports Windows, macOS, and Linux. Platform-specific bugs are a common source of breakage.

- [x] **Windows tested** (either on Windows or via CI)
- [x] **macOS tested** (either on macOS or via CI)
- [x] **Linux tested** (CI covers this)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [x] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [x] New features include test coverage
- [x] Bug fixes include regression tests

## Screenshots

<!-- Required for UI changes. Delete if not applicable. -->

| Before | After |
|--------|-------|
|        |       |

## Feature Toggle

<!-- If feature is incomplete or experimental, how is it hidden from users? -->
<!-- This ensures incomplete work can be merged without affecting production. -->

- [ ] Behind localStorage flag: `use_feature_name`
- [ ] Behind settings toggle
- [ ] Behind environment variable/config
- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

<!-- Does this PR introduce breaking changes? If yes, describe what breaks and migration steps. -->
<!-- Delete this section if not applicable. -->

**Breaking:** No

**Details:**
The `AgentProcess.process` type change from `ChildProcess` to `ChildProcess | null` is backward compatible - all existing code that accesses `process` now includes null checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of process tracking and lifecycle handling for tasks that are started, killed, or interrupted before fully spawning.
  * Ensures cleanup now occurs reliably when a process fails to start or is terminated during async setup.

* **Refactor**
  * Introduced explicit handling for a "pending" process state to better represent in-progress spawns and avoid race conditions.

* **Tests**
  * Stabilized integration tests by adjusting timing to ensure exit handlers attach before process exit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->