### PR TITLE
feat(sidebar): add collapsible sidebar toggle

### DIFF
--- a/apps/frontend/src/shared/i18n/locales/en/navigation.json
+++ b/apps/frontend/src/shared/i18n/locales/en/navigation.json
@@ -21,7 +21,9 @@
   "actions": {
     "settings": "Settings",
     "help": "Help & Feedback",
-    "newTask": "New Task"
+    "newTask": "New Task",
+    "collapseSidebar": "Collapse Sidebar",
+    "expandSidebar": "Expand Sidebar"
   },
   "tooltips": {
     "settings": "Application Settings",

--- a/apps/frontend/src/shared/i18n/locales/fr/navigation.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/navigation.json
@@ -21,7 +21,9 @@
   "actions": {
     "settings": "Paramètres",
     "help": "Aide & Feedback",
-    "newTask": "Nouvelle tâche"
+    "newTask": "Nouvelle tâche",
+    "collapseSidebar": "Réduire la barre latérale",
+    "expandSidebar": "Développer la barre latérale"
   },
   "tooltips": {
     "settings": "Paramètres de l'application",

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -288,6 +288,8 @@ export interface AppSettings {
   autoNameClaudeTerminals?: boolean;
   // Track which version warnings have been shown (e.g., ["2.7.5"])
   seenVersionWarnings?: string[];
+  // Sidebar collapsed state (icons only when true)
+  sidebarCollapsed?: boolean;
 }
 
 // Auto-Claude Source Environment Configuration (for auto-claude repo .env)


### PR DESCRIPTION
## Summary
- Add toggle button to collapse/expand the sidebar (like shadcn pattern)
- When collapsed, sidebar shows icons only with tooltips on hover
- State persists in user settings across sessions
- Smooth 300ms transition animation

## Test plan
- [ ] Click the toggle button (panel icon below header) to collapse sidebar
- [ ] Verify icons-only view with tooltips on hover
- [ ] Click again to expand - verify full labels return
- [ ] Restart app - verify collapsed state persists
- [ ] Test keyboard shortcuts still work when collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible sidebar with new toggle button in the header for easy collapse/expand control
  * Collapsed mode displays navigation items as icons only; hover tooltips reveal labels and shortcuts
  * Expanded mode displays full labels and shortcuts as before with responsive width transitions
  * Added localization support for collapse/expand actions in English and French

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->