### PR TITLE
fix(windows): stabilize CredRead Add-Type + FILETIME handling

### DIFF
--- a/apps/frontend/src/main/claude-profile-manager.ts
+++ b/apps/frontend/src/main/claude-profile-manager.ts
@@ -504,7 +504,7 @@ export class ClaudeProfileManager {
         : profile.configDir;
       env.CLAUDE_CONFIG_DIR = normalize(expandedConfigDir);
       if (process.env.DEBUG === 'true') {
-        console.warn('[ClaudeProfileManager] Using CLAUDE_CONFIG_DIR for profile:', profile.name, expandedConfigDir);
+        console.warn('[ClaudeProfileManager] Using CLAUDE_CONFIG_DIR for profile:', profile.name, env.CLAUDE_CONFIG_DIR);
       }
     } else {
       console.warn('[ClaudeProfileManager] Profile has no configDir configured:', profile?.name);

--- a/apps/frontend/src/main/claude-profile/credential-utils.ts
+++ b/apps/frontend/src/main/claude-profile/credential-utils.ts
@@ -804,23 +804,19 @@ function getCredentialsFromWindowsCredentialManager(configDir?: string, forceRef
 
       # Use CredRead from advapi32.dll to read generic credentials
       $sig = @'
-      using System;
-      using System.Runtime.InteropServices;
-      using System.Runtime.InteropServices.ComTypes;
-
-      [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
 
-      [DllImport("advapi32.dll", SetLastError = true)]
+      [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true)]
       public static extern bool CredFree(IntPtr cred);
 
-      [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public struct CREDENTIAL {
         public int Flags;
         public int Type;
         public string TargetName;
         public string Comment;
-        public FILETIME LastWritten;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
         public int CredentialBlobSize;
         public IntPtr CredentialBlob;
         public int Persist;
@@ -1381,23 +1377,19 @@ function getFullCredentialsFromWindowsCredentialManager(configDir?: string): Ful
 
       # Use CredRead from advapi32.dll to read generic credentials
       $sig = @'
-      using System;
-      using System.Runtime.InteropServices;
-      using System.Runtime.InteropServices.ComTypes;
-
-      [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
 
-      [DllImport("advapi32.dll", SetLastError = true)]
+      [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true)]
       public static extern bool CredFree(IntPtr cred);
 
-      [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public struct CREDENTIAL {
         public int Flags;
         public int Type;
         public string TargetName;
         public string Comment;
-        public FILETIME LastWritten;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
         public int CredentialBlobSize;
         public IntPtr CredentialBlob;
         public int Persist;
@@ -1914,7 +1906,7 @@ function updateWindowsCredentialManagerCredentials(
 
       # Use CredWrite from advapi32.dll to write generic credentials
       $sig = @'
-      [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public struct CREDENTIAL {
         public int Flags;
         public int Type;
@@ -1930,7 +1922,7 @@ function updateWindowsCredentialManagerCredentials(
         public string UserName;
       }
 
-      [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+      [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
       public static extern bool CredWrite(ref CREDENTIAL credential, int flags);
 '@
       Add-Type -MemberDefinition $sig -Namespace Win32 -Name Credential

--- a/apps/frontend/src/main/claude-profile/credential-utils.ts
+++ b/apps/frontend/src/main/claude-profile/credential-utils.ts
@@ -804,11 +804,31 @@ function getCredentialsFromWindowsCredentialManager(configDir?: string, forceRef
 
       # Use CredRead from advapi32.dll to read generic credentials
       $sig = @'
+      using System;
+      using System.Runtime.InteropServices;
+      using System.Runtime.InteropServices.ComTypes;
+
       [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
       public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
 
       [DllImport("advapi32.dll", SetLastError = true)]
       public static extern bool CredFree(IntPtr cred);
+
+      [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+      public struct CREDENTIAL {
+        public int Flags;
+        public int Type;
+        public string TargetName;
+        public string Comment;
+        public FILETIME LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public int Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+      }
 '@
       Add-Type -MemberDefinition $sig -Namespace Win32 -Name Credential
 
@@ -818,7 +838,7 @@ function getCredentialsFromWindowsCredentialManager(configDir?: string, forceRef
 
       if ($success) {
         try {
-          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][System.Management.Automation.PSCredential].Assembly.GetType('Microsoft.PowerShell.Commands.CREDENTIAL'))
+          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][Win32.CREDENTIAL])
 
           # Read the credential blob (password field)
           $blobSize = $cred.CredentialBlobSize
@@ -1361,11 +1381,31 @@ function getFullCredentialsFromWindowsCredentialManager(configDir?: string): Ful
 
       # Use CredRead from advapi32.dll to read generic credentials
       $sig = @'
+      using System;
+      using System.Runtime.InteropServices;
+      using System.Runtime.InteropServices.ComTypes;
+
       [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
       public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
 
       [DllImport("advapi32.dll", SetLastError = true)]
       public static extern bool CredFree(IntPtr cred);
+
+      [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+      public struct CREDENTIAL {
+        public int Flags;
+        public int Type;
+        public string TargetName;
+        public string Comment;
+        public FILETIME LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public int Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+      }
 '@
       Add-Type -MemberDefinition $sig -Namespace Win32 -Name Credential
 
@@ -1375,7 +1415,7 @@ function getFullCredentialsFromWindowsCredentialManager(configDir?: string): Ful
 
       if ($success) {
         try {
-          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][System.Management.Automation.PSCredential].Assembly.GetType('Microsoft.PowerShell.Commands.CREDENTIAL'))
+          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][Win32.CREDENTIAL])
 
           # Read the credential blob (password field)
           $blobSize = $cred.CredentialBlobSize

--- a/apps/frontend/src/main/ipc-handlers/terminal-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal-handlers.ts
@@ -160,10 +160,18 @@ export function registerTerminalHandlers(
             };
           }
 
+          // Expand ~ to home directory for filesystem operations
+          // Note: We keep the original configDir with ~ for storage (more portable)
+          // but expand it for filesystem operations
+          const { homedir } = await import('os');
+          const expandedConfigDir = profile.configDir.startsWith('~')
+            ? profile.configDir.replace(/^~/, homedir())
+            : profile.configDir;
+
           // Ensure config directory exists
           const { mkdirSync, existsSync } = await import('fs');
-          if (!existsSync(profile.configDir)) {
-            mkdirSync(profile.configDir, { recursive: true });
+          if (!existsSync(expandedConfigDir)) {
+            mkdirSync(expandedConfigDir, { recursive: true });
           }
         }
 

--- a/docs/bugs/1525-windows-path-normalize.md
+++ b/docs/bugs/1525-windows-path-normalize.md
@@ -1,0 +1,94 @@
+# Bug #1525: Windows Path Normalization and Credential Lookup Failures
+
+## Summary
+
+Windows path separator inconsistencies caused credential lookup failures when using Claude profiles. The fix normalizes paths before hashing and adds a file-based credential fallback for Windows.
+
+## Root Cause
+
+Two separate issues were discovered:
+
+### Issue 1: Path Separator Inconsistency
+
+Claude CLI normalizes paths internally before hashing the `configDir` to create unique credential storage keys. Auto Claude was not doing the same normalization, resulting in hash mismatches.
+
+**Example:**
+- Stored configDir: `C:\Users\bill/.claude-profiles/sc` (mixed separators)
+- Claude CLI hashes: `C:\Users\bill\.claude-profiles\sc` (normalized)
+- Auto Claude hashed: `C:\Users\bill/.claude-profiles/sc` (not normalized)
+- Result: Different hashes = credentials not found
+
+### Issue 2: Windows Credential Storage Location
+
+Claude CLI on Windows sometimes stores credentials in `.credentials.json` file instead of Windows Credential Manager. Auto Claude only checked Credential Manager, missing file-based credentials.
+
+### Issue 3: Tilde Expansion in Profile Creation
+
+The `CLAUDE_PROFILE_SAVE` handler passed `configDir` with `~` prefix directly to `existsSync`/`mkdirSync`, which don't understand `~` expansion. This caused directory creation to fail for new profiles.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `credential-utils.ts` | Added `path.normalize()` before hashing; added Windows file fallback functions |
+| `claude-profile-manager.ts` | Added `path.normalize()` in `getActiveProfileEnv()` and `getProfileEnv()` |
+| `terminal-handlers.ts` | Fixed `~` expansion before filesystem operations |
+| `credential-utils.test.ts` | Added tests for Windows file fallback scenarios |
+
+## Fix Details
+
+### Path Normalization
+
+Added `path.normalize()` calls before hashing configDir paths:
+
+```typescript
+// credential-utils.ts - getKeychainServiceName()
+const normalizedConfigDir = normalize(expandedConfigDir);
+const hash = calculateConfigDirHash(normalizedConfigDir);
+```
+
+```typescript
+// claude-profile-manager.ts - getActiveProfileEnv() and getProfileEnv()
+env.CLAUDE_CONFIG_DIR = normalize(expandedConfigDir);
+```
+
+### Windows File Fallback
+
+Added functions to read credentials from `.credentials.json` when Credential Manager doesn't have them:
+
+- `getWindowsCredentialsPath()` - Returns path to `.credentials.json`
+- `getCredentialsFromWindowsFile()` - Reads basic credentials from file
+- `getCredentialsFromWindows()` - Tries Credential Manager first, falls back to file
+- `getFullCredentialsFromWindowsFile()` - Reads full credentials (with refresh token)
+- `getFullCredentialsFromWindows()` - Wrapper with fallback for full credentials
+
+### Tilde Expansion Fix
+
+```typescript
+// terminal-handlers.ts - CLAUDE_PROFILE_SAVE handler
+const expandedConfigDir = profile.configDir.startsWith('~')
+  ? profile.configDir.replace(/^~/, homedir())
+  : profile.configDir;
+
+if (!existsSync(expandedConfigDir)) {
+  mkdirSync(expandedConfigDir, { recursive: true });
+}
+```
+
+## Testing
+
+- All 2502 tests pass
+- Manually tested on Windows:
+  - Creating new profiles works
+  - Both OAuth profiles authenticate correctly
+  - Usage data fetches correctly for both profiles
+  - Mixed path separator configDirs are handled correctly
+
+## PR
+
+- PR #1538: https://github.com/AndyMik90/Auto-Claude/pull/1538
+
+## Related
+
+- Issue #1525: https://github.com/AndyMik90/Auto-Claude/issues/1525
+- Commit 1e72c8d7: Original hash-based credential isolation commit


### PR DESCRIPTION
## Summary\nFix Windows Credential Manager reads by making the embedded C# compile under Add-Type -MemberDefinition and by marshalling the correct Win32 CREDENTIAL struct.\n\n## Changes\n- Marshal with [Win32.CREDENTIAL] instead of the PowerShell-internal Microsoft.PowerShell.Commands.CREDENTIAL\n- Remove using directives from member definitions\n- Fully qualify attributes/types (e.g., System.Runtime.InteropServices.DllImport)\n- Disambiguate FILETIME with System.Runtime.InteropServices.ComTypes.FILETIME\n- Apply the same fixes across both credential-read paths and the credential-write definition\n\n## Validation\n- Ran 
pm run build successfully in the 1538 worktree\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path normalization inconsistencies across Windows, macOS, and Linux for improved credential lookups.
  * Added Windows file-based credential fallback when standard credential retrieval is unavailable.
  * Fixed tilde (~) expansion in profile configuration directory paths.

* **Tests**
  * Expanded test coverage for credential retrieval edge cases and cross-platform fallback scenarios.

* **Documentation**
  * Added documentation detailing Windows path normalization and credential handling fixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->