### PR TITLE
perf(frontend): async parallel worktree listing to prevent UI freezes

### DIFF
--- a/apps/frontend/src/main/cli-tool-manager.ts
+++ b/apps/frontend/src/main/cli-tool-manager.ts
@@ -307,7 +307,7 @@ class CLIToolManager {
     // Check cache first
     const cached = this.cache.get(tool);
     if (cached) {
-      console.warn(
+      console.debug(
         `[CLI Tools] Using cached ${tool}: ${cached.path} (${cached.source})`
       );
       return cached.path;
@@ -1033,7 +1033,7 @@ class CLIToolManager {
     // Check cache first (instant return if cached)
     const cached = this.cache.get(tool);
     if (cached) {
-      console.warn(
+      console.debug(
         `[CLI Tools] Using cached ${tool}: ${cached.path} (${cached.source})`
       );
       return cached.path;

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -60,7 +60,7 @@ export interface TaskAPI {
   mergeWorktreePreview: (taskId: string) => Promise<IPCResult<import('../../shared/types').WorktreeMergeResult>>;
   discardWorktree: (taskId: string, skipStatusChange?: boolean) => Promise<IPCResult<import('../../shared/types').WorktreeDiscardResult>>;
   clearStagedState: (taskId: string) => Promise<IPCResult<{ cleared: boolean }>>;
-  listWorktrees: (projectId: string) => Promise<IPCResult<import('../../shared/types').WorktreeListResult>>;
+  listWorktrees: (projectId: string, options?: { includeStats?: boolean }) => Promise<IPCResult<import('../../shared/types').WorktreeListResult>>;
   worktreeOpenInIDE: (worktreePath: string, ide: SupportedIDE, customPath?: string) => Promise<IPCResult<{ opened: boolean }>>;
   worktreeOpenInTerminal: (worktreePath: string, terminal: SupportedTerminal, customPath?: string) => Promise<IPCResult<{ opened: boolean }>>;
   worktreeDetectTools: () => Promise<IPCResult<{ ides: Array<{ id: string; name: string; path: string; installed: boolean }>; terminals: Array<{ id: string; name: string; path: string; installed: boolean }> }>>;
@@ -161,8 +161,8 @@ export const createTaskAPI = (): TaskAPI => ({
   clearStagedState: (taskId: string): Promise<IPCResult<{ cleared: boolean }>> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_CLEAR_STAGED_STATE, taskId),
 
-  listWorktrees: (projectId: string): Promise<IPCResult<import('../../shared/types').WorktreeListResult>> =>
-    ipcRenderer.invoke(IPC_CHANNELS.TASK_LIST_WORKTREES, projectId),
+  listWorktrees: (projectId: string, options?: { includeStats?: boolean }): Promise<IPCResult<import('../../shared/types').WorktreeListResult>> =>
+    ipcRenderer.invoke(IPC_CHANNELS.TASK_LIST_WORKTREES, projectId, options),
 
   worktreeOpenInIDE: (worktreePath: string, ide: SupportedIDE, customPath?: string): Promise<IPCResult<{ opened: boolean }>> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_WORKTREE_OPEN_IN_IDE, worktreePath, ide, customPath),

--- a/apps/frontend/src/renderer/components/Worktrees.tsx
+++ b/apps/frontend/src/renderer/components/Worktrees.tsx
@@ -166,7 +166,7 @@ export function Worktrees({ projectId }: WorktreesProps) {
     try {
       // Fetch both task worktrees and terminal worktrees in parallel
       const [taskResult, terminalResult] = await Promise.all([
-        window.electronAPI.listWorktrees(projectId),
+        window.electronAPI.listWorktrees(projectId, { includeStats: true }),
         window.electronAPI.listTerminalWorktrees(selectedProject.path)
       ]);
 
@@ -285,10 +285,10 @@ export function Worktrees({ projectId }: WorktreesProps) {
     worktreePath: worktree.path,
     branch: worktree.branch,
     baseBranch: worktree.baseBranch,
-    commitCount: worktree.commitCount,
-    filesChanged: worktree.filesChanged,
-    additions: worktree.additions,
-    deletions: worktree.deletions
+    commitCount: worktree.commitCount ?? 0,
+    filesChanged: worktree.filesChanged ?? 0,
+    additions: worktree.additions ?? 0,
+    deletions: worktree.deletions ?? 0
   });
 
   // Open Create PR dialog
@@ -586,19 +586,19 @@ export function Worktrees({ projectId }: WorktreesProps) {
                         <div className="flex flex-wrap gap-4 text-sm mb-4">
                           <div className="flex items-center gap-1.5 text-muted-foreground">
                             <FileCode className="h-3.5 w-3.5" />
-                            <span>{worktree.filesChanged} files changed</span>
+                            <span>{worktree.filesChanged ?? 0} files changed</span>
                           </div>
                           <div className="flex items-center gap-1.5 text-muted-foreground">
                             <ChevronRight className="h-3.5 w-3.5" />
-                            <span>{worktree.commitCount} commits ahead</span>
+                            <span>{worktree.commitCount ?? 0} commits ahead</span>
                           </div>
                           <div className="flex items-center gap-1.5 text-success">
                             <Plus className="h-3.5 w-3.5" />
-                            <span>{worktree.additions}</span>
+                            <span>{worktree.additions ?? 0}</span>
                           </div>
                           <div className="flex items-center gap-1.5 text-destructive">
                             <Minus className="h-3.5 w-3.5" />
-                            <span>{worktree.deletions}</span>
+                            <span>{worktree.deletions ?? 0}</span>
                           </div>
                         </div>
 
@@ -790,7 +790,7 @@ export function Worktrees({ projectId }: WorktreesProps) {
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-muted-foreground">Changes</span>
                     <span>
-                      {selectedWorktree.commitCount} commits, {selectedWorktree.filesChanged} files
+                      {selectedWorktree.commitCount ?? 0} commits, {selectedWorktree.filesChanged ?? 0} files
                     </span>
                   </div>
                 </div>

--- a/apps/frontend/src/renderer/components/terminal/WorktreeSelector.tsx
+++ b/apps/frontend/src/renderer/components/terminal/WorktreeSelector.tsx
@@ -62,7 +62,7 @@ export function WorktreeSelector({
       // Fetch terminal worktrees, task worktrees, and other worktrees in parallel
       const [terminalResult, taskResult, otherResult] = await Promise.all([
         window.electronAPI.listTerminalWorktrees(projectPath),
-        project?.id ? window.electronAPI.listWorktrees(project.id) : Promise.resolve(null),
+        project?.id ? window.electronAPI.listWorktrees(project.id, { includeStats: false }) : Promise.resolve(null),
         window.electronAPI.listOtherWorktrees(projectPath),
       ]);
 

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -182,7 +182,7 @@ export interface ElectronAPI {
   createWorktreePR: (taskId: string, options?: WorktreeCreatePROptions) => Promise<IPCResult<WorktreeCreatePRResult>>;
   discardWorktree: (taskId: string, skipStatusChange?: boolean) => Promise<IPCResult<WorktreeDiscardResult>>;
   clearStagedState: (taskId: string) => Promise<IPCResult<{ cleared: boolean }>>;
-  listWorktrees: (projectId: string) => Promise<IPCResult<WorktreeListResult>>;
+  listWorktrees: (projectId: string, options?: { includeStats?: boolean }) => Promise<IPCResult<WorktreeListResult>>;
   worktreeOpenInIDE: (worktreePath: string, ide: SupportedIDE, customPath?: string) => Promise<IPCResult<{ opened: boolean }>>;
   worktreeOpenInTerminal: (worktreePath: string, terminal: SupportedTerminal, customPath?: string) => Promise<IPCResult<{ opened: boolean }>>;
   worktreeDetectTools: () => Promise<IPCResult<{ ides: Array<{ id: string; name: string; path: string; installed: boolean }>; terminals: Array<{ id: string; name: string; path: string; installed: boolean }> }>>;

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -442,10 +442,10 @@ export interface WorktreeListItem {
   path: string;
   branch: string;
   baseBranch: string;
-  commitCount: number;
-  filesChanged: number;
-  additions: number;
-  deletions: number;
+  commitCount?: number;
+  filesChanged?: number;
+  additions?: number;
+  deletions?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Opening the WorktreeSelector dropdown or the Worktrees page spawned ~160 synchronous (`execFileSync`) git subprocesses sequentially on the Electron main thread, freezing the UI. This PR converts the worktree listing handler to async parallel execution, eliminating main thread blocking.

## Problem

With ~40 task worktrees, the `TASK_LIST_WORKTREES` IPC handler made 3-5 synchronous git calls per worktree (branch detection, commit count, diff stats), totaling ~160 blocking calls. Additionally, `getEffectiveBaseBranch` redundantly detected main/master per worktree (same result for all), and `cli-tool-manager.ts` emitted `console.warn` on every git cache hit (160+ warn lines).

## Solution

- **Async execution**: Replace `execFileSync` with `execFileAsync` (promisified `execFile`)
- **Parallel processing**: Process all worktrees concurrently via `Promise.allSettled`
- **Conditional stats**: Add `includeStats` option — `false` for fast dropdown listing (1 git call per worktree), `true` for full stats on Worktrees page (3 parallel git calls per worktree)
- **Cached branch detection**: Detect project default branch once per project instead of per worktree
- **Bug fix**: Detection guard now also runs when `mainBranch` setting is set but fails regex validation, preventing blind fallback to `'main'`
- **Log noise reduction**: Downgrade cache-hit log from `console.warn` to `console.debug`

## Changes

| File | Change |
|------|--------|
| `worktree-handlers.ts` | Major refactor: async handler, parallel execution, `includeStats` option, cached branch detection, detection guard fix |
| `task.ts` | Make `commitCount`, `filesChanged`, `additions`, `deletions` optional on `WorktreeListItem` |
| `ipc.ts` | Update `listWorktrees` type signature with `options` parameter |
| `task-api.ts` | Pass `options` parameter through IPC bridge |
| `WorktreeSelector.tsx` | Pass `{ includeStats: false }` for fast dropdown |
| `Worktrees.tsx` | Pass `{ includeStats: true }`, add `?? 0` fallbacks for optional stats |
| `cli-tool-manager.ts` | `console.warn` → `console.debug` for cache hits |

## Performance Impact

| Scenario | Before | After |
|---|---|---|
| Dropdown (40 worktrees) | ~160 sync git calls, sequential | ~40 async calls, parallel |
| Worktrees page (40 worktrees) | ~160 sync git calls, sequential | ~120 async calls, parallel |
| Base branch detection | 2 calls per worktree (80 total) | 1-2 calls total per project |
| Main thread blocking | Full duration of all git calls | Zero (all async) |

## Testing

- [x] TypeScript strict typecheck passes
- [x] Biome CI lint passes
- [x] All 2500 frontend tests pass (99 test files)
- [x] Frontend production build succeeds
- [x] All 2021 backend tests pass
- [x] Pre-PR validation (9-agent review) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree listings now optionally display additional statistics including commit count, files changed, additions, and deletions.

* **Refactor**
  * Optimized internal worktree data processing with improved performance handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->