### PR TITLE
Remove Lock Indicator Line from Kanban Board

### DIFF
--- a/apps/frontend/src/renderer/components/KanbanBoard.tsx
+++ b/apps/frontend/src/renderer/components/KanbanBoard.tsx
@@ -597,7 +597,7 @@ const DroppableColumn = memo(function DroppableColumn({ status, tasks, onTaskCli
             "absolute right-0 top-0 bottom-0 w-1 touch-none z-10",
             "transition-colors duration-150",
             isLocked
-              ? "cursor-not-allowed bg-amber-500/20 hover:bg-amber-500/30"
+              ? "cursor-not-allowed bg-transparent"
               : "cursor-col-resize hover:bg-primary/40",
             isResizing && !isLocked && "bg-primary/60"
           )}


### PR DESCRIPTION
Remove the amber vertical line that appears on the right edge of a Kanban column when it is locked. The lock icon in the column header is sufficient visual feedback; the additional amber line on the resize handle is redundant and should be hidden.