### PR TITLE
fix(windows): fix Windows Credential Manager authentication (#1525)

### DIFF
--- a/apps/frontend/src/main/claude-profile/credential-utils.ts
+++ b/apps/frontend/src/main/claude-profile/credential-utils.ts
@@ -176,9 +176,18 @@ export function getKeychainServiceName(configDir?: string): string {
   }
 
   // Normalize the configDir: expand ~ and resolve to absolute path
-  const normalizedConfigDir = configDir.startsWith('~')
+  let normalizedConfigDir = configDir.startsWith('~')
     ? join(homedir(), configDir.slice(1))
     : configDir;
+
+  // CRITICAL: Normalize path separators to match Claude CLI behavior on Windows
+  // Claude CLI on Windows uses backslashes, so we must too for hash consistency
+  // Mixed slashes (C:\Users\bill/.claude-profiles) produce different hashes than
+  // consistent slashes (C:\Users\bill\.claude-profiles)
+  // Only normalize if this looks like a Windows path (has drive letter or backslashes)
+  if (process.platform === 'win32' && /^[A-Za-z]:|\\/.test(normalizedConfigDir)) {
+    normalizedConfigDir = normalizedConfigDir.replace(/\//g, '\\');
+  }
 
   // ALL profiles now use hash-based keychain entries for isolation
   // This prevents interference with external Claude Code CLI
@@ -804,29 +813,52 @@ function getCredentialsFromWindowsCredentialManager(configDir?: string, forceRef
   try {
     // PowerShell script to read from Credential Manager
     // Uses the Windows Credential Manager API via .NET
+    // NOTE: The CREDENTIAL struct must use IntPtr for string fields (blittable requirement)
+    // and strings must be manually marshaled after PtrToStructure
     const psScript = `
       $ErrorActionPreference = 'Stop'
-      Add-Type -AssemblyName System.Runtime.WindowsRuntime
 
-      # Use CredRead from advapi32.dll to read generic credentials
-      $sig = @'
-      [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-      public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
+      # Define the CREDENTIAL struct with IntPtr for string fields (required for marshaling)
+      Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
 
-      [DllImport("advapi32.dll", SetLastError = true)]
-      public static extern bool CredFree(IntPtr cred);
+[StructLayout(LayoutKind.Sequential)]
+public struct CREDENTIAL {
+    public uint Flags;
+    public uint Type;
+    public IntPtr TargetName;
+    public IntPtr Comment;
+    public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+    public uint CredentialBlobSize;
+    public IntPtr CredentialBlob;
+    public uint Persist;
+    public uint AttributeCount;
+    public IntPtr Attributes;
+    public IntPtr TargetAlias;
+    public IntPtr UserName;
+}
 '@
-      Add-Type -MemberDefinition $sig -Namespace Win32 -Name Credential
+
+      # Import CredRead and CredFree from advapi32.dll
+      Add-Type -MemberDefinition @'
+[DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+public static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr credentialPtr);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool CredFree(IntPtr cred);
+'@ -Namespace Win32 -Name CredApi
 
       $credPtr = [IntPtr]::Zero
       # CRED_TYPE_GENERIC = 1
-      $success = [Win32.Credential]::CredRead("${escapePowerShellString(targetName)}", 1, 0, [ref]$credPtr)
+      $success = [Win32.CredApi]::CredRead("${escapePowerShellString(targetName)}", 1, 0, [ref]$credPtr)
 
       if ($success) {
         try {
-          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][System.Management.Automation.PSCredential].Assembly.GetType('Microsoft.PowerShell.Commands.CREDENTIAL'))
+          # Marshal the pointer to our CREDENTIAL struct
+          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][CREDENTIAL])
 
-          # Read the credential blob (password field)
+          # Read the credential blob (password field) - contains the JSON
           $blobSize = $cred.CredentialBlobSize
           if ($blobSize -gt 0) {
             $blob = [byte[]]::new($blobSize)
@@ -835,7 +867,7 @@ function getCredentialsFromWindowsCredentialManager(configDir?: string, forceRef
             Write-Output $password
           }
         } finally {
-          [Win32.Credential]::CredFree($credPtr) | Out-Null
+          [Win32.CredApi]::CredFree($credPtr) | Out-Null
         }
       } else {
         # Credential not found - this is expected if user hasn't authenticated
@@ -1223,29 +1255,51 @@ function getFullCredentialsFromWindowsCredentialManager(configDir?: string): Ful
 
   try {
     // PowerShell script to read from Credential Manager (same as basic credentials)
+    // NOTE: The CREDENTIAL struct must use IntPtr for string fields (blittable requirement)
     const psScript = `
       $ErrorActionPreference = 'Stop'
-      Add-Type -AssemblyName System.Runtime.WindowsRuntime
 
-      # Use CredRead from advapi32.dll to read generic credentials
-      $sig = @'
-      [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-      public static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
+      # Define the CREDENTIAL struct with IntPtr for string fields (required for marshaling)
+      Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
 
-      [DllImport("advapi32.dll", SetLastError = true)]
-      public static extern bool CredFree(IntPtr cred);
+[StructLayout(LayoutKind.Sequential)]
+public struct CREDENTIAL {
+    public uint Flags;
+    public uint Type;
+    public IntPtr TargetName;
+    public IntPtr Comment;
+    public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+    public uint CredentialBlobSize;
+    public IntPtr CredentialBlob;
+    public uint Persist;
+    public uint AttributeCount;
+    public IntPtr Attributes;
+    public IntPtr TargetAlias;
+    public IntPtr UserName;
+}
 '@
-      Add-Type -MemberDefinition $sig -Namespace Win32 -Name Credential
+
+      # Import CredRead and CredFree from advapi32.dll
+      Add-Type -MemberDefinition @'
+[DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+public static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr credentialPtr);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool CredFree(IntPtr cred);
+'@ -Namespace Win32 -Name CredApi
 
       $credPtr = [IntPtr]::Zero
       # CRED_TYPE_GENERIC = 1
-      $success = [Win32.Credential]::CredRead("${escapePowerShellString(targetName)}", 1, 0, [ref]$credPtr)
+      $success = [Win32.CredApi]::CredRead("${escapePowerShellString(targetName)}", 1, 0, [ref]$credPtr)
 
       if ($success) {
         try {
-          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][System.Management.Automation.PSCredential].Assembly.GetType('Microsoft.PowerShell.Commands.CREDENTIAL'))
+          # Marshal the pointer to our CREDENTIAL struct
+          $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][CREDENTIAL])
 
-          # Read the credential blob (password field)
+          # Read the credential blob (password field) - contains the JSON
           $blobSize = $cred.CredentialBlobSize
           if ($blobSize -gt 0) {
             $blob = [byte[]]::new($blobSize)
@@ -1254,7 +1308,7 @@ function getFullCredentialsFromWindowsCredentialManager(configDir?: string): Ful
             Write-Output $password
           }
         } finally {
-          [Win32.Credential]::CredFree($credPtr) | Out-Null
+          [Win32.CredApi]::CredFree($credPtr) | Out-Null
         }
       } else {
         # Credential not found - this is expected if user hasn't authenticated


### PR DESCRIPTION
## Summary

Fixes Windows authentication by addressing two issues:

1. **PtrToStructure failure** - The code used a non-existent `PSCredential` assembly type for marshaling the Win32 CREDENTIAL struct, causing "structureType cannot be null" error. Fixed by defining an explicit CREDENTIAL struct with IntPtr fields (required for blittable marshaling).

2. **Path hash mismatch** - Mixed path separators (`C:\Users\bill/.claude-profiles`) produced different credential target hashes than Claude CLI's backslash-only paths (`C:\Users\bill\.claude-profiles`). Fixed by normalizing forward slashes to backslashes on Windows before calculating the hash.

## Test plan

- [x] Manually tested on Windows - authentication now works
- [x] Credentials are correctly read from Windows Credential Manager after `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential consistency on Windows through path normalization to ensure stable credential lookup.
  * Enhanced Windows credential manager integration for more reliable retrieval and storage of credentials.

* **Documentation**
  * Updated internal notes clarifying Windows credential handling and marshaling expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->