### PR TITLE
fix-subtask-name-overflow-in-modal

### DIFF
--- a/apps/frontend/src/renderer/components/task-detail/TaskSubtasks.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskSubtasks.tsx
@@ -58,7 +58,7 @@ export function TaskSubtasks({ task }: TaskSubtasksProps) {
                 <div className="flex items-start gap-2">
                   {getSubtaskStatusIcon(subtask.status)}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
                       <span className={cn(
                         'text-[10px] font-medium px-1.5 py-0.5 rounded-full',
                         subtask.status === 'completed' ? 'bg-success/20 text-success' :


### PR DESCRIPTION
Fix long subtask names overflowing outside their container in the task detail modal. This is a CSS flexbox truncation bug where the `truncate` utility class has no effect because a parent flex container is missing the `min-w-0` constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text truncation and layout behavior in task subtasks display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->