### PR TITLE
Fix Linear API GraphQL Type Mismatch

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/linear-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/linear-handlers.ts
@@ -239,7 +239,7 @@ export function registerLinearHandlers(
 
       try {
         const query = `
-          query($teamId: ID!) {
+          query($teamId: String!) {
             team(id: $teamId) {
               projects {
                 nodes {


### PR DESCRIPTION
Fix GraphQL type mismatch error in LINEAR_GET_PROJECTS handler by changing `$teamId: ID!` to `$teamId: String!`. The Linear GraphQL API's `team(id: ...)` field expects `String!` type, but the query incorrectly declares `$teamId: ID!`, causing HTTP 400 errors.