### PR TITLE
fix: Remove .auto-claude files from git index in new worktrees

### DIFF
--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -720,6 +720,15 @@ class WorktreeManager:
 
         print(f"Created worktree: {worktree_path.name} on branch {branch_name}")
 
+        # Remove .auto-claude files from git index in the new worktree
+        # This prevents files that were tracked in the base branch from being tracked in the worktree
+        result = self._run_git(["ls-files", ".auto-claude/"], cwd=worktree_path)
+        if result.returncode == 0 and result.stdout.strip():
+            print(f"Removing .auto-claude files from git index in worktree...")
+            for file in result.stdout.strip().split("\n"):
+                if file.strip():
+                    self._run_git(["rm", "--cached", file], cwd=worktree_path)
+
         return WorktreeInfo(
             path=worktree_path,
             branch=branch_name,


### PR DESCRIPTION
## Problem

When `.auto-claude` files were tracked in the main branch and later added to `.gitignore`, they are copied to each new worktree when running `git worktree add` and remain tracked in the index.

## Solution

After creating a worktree in `create_worktree()`, remove any `.auto-claude` files from the git index using `git rm --cached`.

## Changes

- `apps/backend/core/worktree.py`: After worktree creation, all `.auto-claude` files are now removed from the git index

## Verification

1. In Helvetiq project: Remove `.auto-claude` files from main branch with `git rm --cached .auto-claude/` and commit
2. Create a new worktree with Auto-Claude
3. Verify that `git ls-files .auto-claude/` returns empty in the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree creation to automatically clean up internal tracking files, preventing unintended file tracking in new worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->