### PR TITLE
fix: correct log order sorting and add configurable log order setting

### DIFF
--- a/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
@@ -263,7 +263,7 @@ export function DisplaySettings({ settings, onSettingsChange }: DisplaySettingsP
               <SelectTrigger id="logOrder" className="w-72">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className="max-h-60 overflow-y-auto">
                 <SelectItem value="chronological">
                   {t('logOrder.chronological')}
                 </SelectItem>

--- a/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
@@ -7,6 +7,7 @@ import { SettingsSection } from './SettingsSection';
 import { useSettingsStore } from '../../stores/settings-store';
 import { UI_SCALE_MIN, UI_SCALE_MAX, UI_SCALE_DEFAULT, UI_SCALE_STEP } from '../../../shared/constants';
 import type { AppSettings } from '../../../shared/types';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 
 interface DisplaySettingsProps {
   settings: AppSettings;
@@ -238,6 +239,39 @@ export function DisplaySettings({ settings, onSettingsChange }: DisplaySettingsP
           <div className="flex justify-between text-xs text-muted-foreground">
             <span>{UI_SCALE_MIN}%</span>
             <span>{UI_SCALE_MAX}%</span>
+          </div>
+        </div>
+
+        {/* Log Order Setting */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between max-w-md">
+            <div className="space-y-1">
+              <Label htmlFor="logOrder" className="text-sm font-medium text-foreground">
+                {t('logOrder.label')}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {t('logOrder.description')}
+              </p>
+            </div>
+            <Select
+              value={settings.logOrder || 'chronological'}
+              onValueChange={(value) => onSettingsChange({
+                ...settings,
+                logOrder: value as 'chronological' | 'reverse-chronological'
+              })}
+            >
+              <SelectTrigger id="logOrder" className="w-56">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="chronological">
+                  {t('logOrder.chronological')}
+                </SelectItem>
+                <SelectItem value="reverse-chronological">
+                  {t('logOrder.reverseChronological')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
       </div>

--- a/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/DisplaySettings.tsx
@@ -260,7 +260,7 @@ export function DisplaySettings({ settings, onSettingsChange }: DisplaySettingsP
                 logOrder: value as 'chronological' | 'reverse-chronological'
               })}
             >
-              <SelectTrigger id="logOrder" className="w-56">
+              <SelectTrigger id="logOrder" className="w-72">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -177,15 +177,15 @@ interface PhaseLogSectionProps {
 
 function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, phaseConfig }: PhaseLogSectionProps) {
   const Icon = PHASE_ICONS[phase];
-  const { settings } = useSettingsStore();
+  const logOrder = useSettingsStore(s => s.settings.logOrder);
   const status = phaseLog?.status || 'pending';
   const hasEntries = (phaseLog?.entries.length || 0) > 0;
 
   // Memoize sorted entries to avoid re-calculating on every render
   const displayedEntries = useMemo(() => {
     const entries = phaseLog?.entries || [];
-    return settings.logOrder === 'chronological' ? [...entries].reverse() : entries;
-  }, [phaseLog?.entries, settings.logOrder]);
+    return logOrder === 'chronological' ? [...entries].reverse() : entries;
+  }, [phaseLog?.entries, logOrder]);
 
   const getStatusBadge = () => {
     switch (status) {

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   Terminal,
   Loader2,
@@ -181,6 +181,12 @@ function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, p
   const status = phaseLog?.status || 'pending';
   const hasEntries = (phaseLog?.entries.length || 0) > 0;
 
+  // Memoize sorted entries to avoid re-calculating on every render
+  const displayedEntries = useMemo(() => {
+    const entries = phaseLog?.entries || [];
+    return settings.logOrder === 'chronological' ? [...entries].reverse() : entries;
+  }, [phaseLog?.entries, settings.logOrder]);
+
   const getStatusBadge = () => {
     switch (status) {
       case 'active':
@@ -275,10 +281,7 @@ function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, p
           {!hasEntries ? (
             <p className="text-xs text-muted-foreground italic">No logs yet</p>
           ) : (
-            (settings.logOrder === 'chronological'
-              ? [...(phaseLog?.entries || [])].reverse()
-              : (phaseLog?.entries || [])
-            ).map((entry, idx) => (
+            displayedEntries.map((entry, idx) => (
               <LogEntry key={`${entry.timestamp}-${idx}`} entry={entry} />
             ))
           )}

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -182,9 +182,10 @@ function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, p
   const hasEntries = (phaseLog?.entries.length || 0) > 0;
 
   // Memoize sorted entries to avoid re-calculating on every render
+  // Entries are naturally in chronological order (oldest first from append())
   const displayedEntries = useMemo(() => {
     const entries = phaseLog?.entries || [];
-    return logOrder === 'chronological' ? [...entries].reverse() : entries;
+    return logOrder === 'reverse-chronological' ? [...entries].reverse() : entries;
   }, [phaseLog?.entries, logOrder]);
 
   const getStatusBadge = () => {
@@ -322,7 +323,8 @@ function LogEntry({ entry }: LogEntryProps) {
   const formatTime = (timestamp: string) => {
     try {
       const date = new Date(timestamp);
-      return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      // Use system locale for date and time formatting
+      return date.toLocaleString();
     } catch {
       return '';
     }

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -282,8 +282,8 @@ function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, p
           {!hasEntries ? (
             <p className="text-xs text-muted-foreground italic">No logs yet</p>
           ) : (
-            displayedEntries.map((entry, idx) => (
-              <LogEntry key={`${entry.timestamp}-${idx}`} entry={entry} />
+            displayedEntries.map((entry) => (
+              <LogEntry key={`${entry.timestamp}-${entry.type}-${entry.content}`} entry={entry} />
             ))
           )}
         </div>

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -21,6 +21,7 @@ import {
 import { Badge } from '../ui/badge';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
 import { cn } from '../../lib/utils';
+import { useSettingsStore } from '../../stores/settings-store';
 import type { Task, TaskLogs, TaskLogPhase, TaskPhaseLog, TaskLogEntry, TaskMetadata } from '../../../shared/types';
 import type { PhaseModelConfig, ThinkingLevel, ModelTypeShort } from '../../../shared/types/settings';
 
@@ -176,6 +177,7 @@ interface PhaseLogSectionProps {
 
 function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, phaseConfig }: PhaseLogSectionProps) {
   const Icon = PHASE_ICONS[phase];
+  const { settings } = useSettingsStore();
   const status = phaseLog?.status || 'pending';
   const hasEntries = (phaseLog?.entries.length || 0) > 0;
 
@@ -273,7 +275,10 @@ function PhaseLogSection({ phase, phaseLog, isExpanded, onToggle, isTaskStuck, p
           {!hasEntries ? (
             <p className="text-xs text-muted-foreground italic">No logs yet</p>
           ) : (
-            phaseLog?.entries.map((entry, idx) => (
+            (settings.logOrder === 'chronological'
+              ? [...(phaseLog?.entries || [])].reverse()
+              : (phaseLog?.entries || [])
+            ).map((entry, idx) => (
               <LogEntry key={`${entry.timestamp}-${idx}`} entry={entry} />
             ))
           )}

--- a/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
+++ b/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
@@ -94,7 +94,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
   const [isCreatingPR, setIsCreatingPR] = useState(false);
 
   const selectedProject = useProjectStore((state) => state.getSelectedProject());
-  const { settings } = useSettingsStore();
+  const logOrder = useSettingsStore(s => s.settings.logOrder);
   const isRunning = task.status === 'in_progress';
   // isActiveTask includes ai_review for stuck detection (CHANGELOG documents this feature)
   const isActiveTask = task.status === 'in_progress' || task.status === 'ai_review';
@@ -136,7 +136,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
   // Handle scroll events in logs to detect if user scrolled away from anchor
   const handleLogsScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as HTMLDivElement;
-    const isReverseOrder = settings.logOrder === 'reverse-chronological';
+    const isReverseOrder = logOrder === 'reverse-chronological';
 
     // Check distance from top for reverse order, bottom for chronological
     const isAtAnchor = isReverseOrder
@@ -148,7 +148,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
 
   // Auto-scroll logs to anchor (top for reverse, bottom for chronological) only if user hasn't scrolled away
   useEffect(() => {
-    const isReverseOrder = settings.logOrder === 'reverse-chronological';
+    const isReverseOrder = logOrder === 'reverse-chronological';
 
     if (activeTab === 'logs' && !isUserScrolledUp) {
       if (isReverseOrder && logsContainerRef.current) {
@@ -157,7 +157,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
         logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }
-  }, [activeTab, isUserScrolledUp, settings.logOrder]);
+  }, [activeTab, isUserScrolledUp, logOrder]);
 
   // Reset scroll state when switching to logs tab
   useEffect(() => {

--- a/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
+++ b/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
@@ -94,6 +94,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
   const [isCreatingPR, setIsCreatingPR] = useState(false);
 
   const selectedProject = useProjectStore((state) => state.getSelectedProject());
+  const { settings } = useSettingsStore();
   const isRunning = task.status === 'in_progress';
   // isActiveTask includes ai_review for stuck detection (CHANGELOG documents this feature)
   const isActiveTask = task.status === 'in_progress' || task.status === 'ai_review';
@@ -135,7 +136,6 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
   // Handle scroll events in logs to detect if user scrolled away from anchor
   const handleLogsScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as HTMLDivElement;
-    const settings = useSettingsStore.getState().settings;
     const isReverseOrder = settings.logOrder === 'reverse-chronological';
 
     // Check distance from top for reverse order, bottom for chronological
@@ -148,7 +148,6 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
 
   // Auto-scroll logs to anchor (top for reverse, bottom for chronological) only if user hasn't scrolled away
   useEffect(() => {
-    const settings = useSettingsStore.getState().settings;
     const isReverseOrder = settings.logOrder === 'reverse-chronological';
 
     if (activeTab === 'logs' && !isUserScrolledUp) {
@@ -158,7 +157,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
         logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }
-  }, [activeTab, isUserScrolledUp]);
+  }, [activeTab, isUserScrolledUp, settings.logOrder]);
 
   // Reset scroll state when switching to logs tab
   useEffect(() => {

--- a/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
+++ b/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useProjectStore } from '../../../stores/project-store';
+import { useSettingsStore } from '../../../stores/settings-store';
 import { checkTaskRunning, isIncompleteHumanReview, getTaskProgress, useTaskStore, loadTasks, hasRecentActivity } from '../../../stores/task-store';
 import type { Task, TaskLogs, TaskLogPhase, WorktreeStatus, WorktreeDiff, MergeConflict, MergeStats, GitConflictInfo, ImageAttachment } from '../../../../shared/types';
 
@@ -131,17 +132,31 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
     return () => clearInterval(intervalId);
   }, [task.id, isActiveTask]);
 
-  // Handle scroll events in logs to detect if user scrolled up
+  // Handle scroll events in logs to detect if user scrolled away from anchor
   const handleLogsScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as HTMLDivElement;
-    const isNearBottom = target.scrollHeight - target.scrollTop - target.clientHeight < 100;
-    setIsUserScrolledUp(!isNearBottom);
+    const settings = useSettingsStore.getState().settings;
+    const isReverseOrder = settings.logOrder === 'reverse-chronological';
+
+    // Check distance from top for reverse order, bottom for chronological
+    const isAtAnchor = isReverseOrder
+      ? target.scrollTop < 100
+      : target.scrollHeight - target.scrollTop - target.clientHeight < 100;
+
+    setIsUserScrolledUp(!isAtAnchor);
   };
 
-  // Auto-scroll logs to bottom only if user hasn't scrolled up
+  // Auto-scroll logs to anchor (top for reverse, bottom for chronological) only if user hasn't scrolled away
   useEffect(() => {
-    if (activeTab === 'logs' && logsEndRef.current && !isUserScrolledUp) {
-      logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    const settings = useSettingsStore.getState().settings;
+    const isReverseOrder = settings.logOrder === 'reverse-chronological';
+
+    if (activeTab === 'logs' && !isUserScrolledUp) {
+      if (isReverseOrder && logsContainerRef.current) {
+        logsContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+      } else if (!isReverseOrder && logsEndRef.current) {
+        logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
     }
   }, [activeTab, isUserScrolledUp]);
 

--- a/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
+++ b/apps/frontend/src/renderer/components/task-detail/hooks/useTaskDetail.ts
@@ -157,7 +157,7 @@ export function useTaskDetail({ task }: UseTaskDetailOptions) {
         logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }
-  }, [activeTab, isUserScrolledUp, logOrder]);
+  }, [activeTab, isUserScrolledUp, logOrder, phaseLogs]);
 
   // Reset scroll state when switching to logs tab
   useEffect(() => {

--- a/apps/frontend/src/shared/constants/config.ts
+++ b/apps/frontend/src/shared/constants/config.ts
@@ -53,6 +53,8 @@ export const DEFAULT_APP_SETTINGS = {
   changelogEmojiLevel: 'none' as const,
   // UI Scale (default 100% - standard size)
   uiScale: UI_SCALE_DEFAULT,
+  // Log order setting for task detail view (default chronological - oldest first)
+  logOrder: 'chronological' as const,
   // Beta updates opt-in (receive pre-release versions)
   betaUpdates: false,
   // Language preference (default to English)

--- a/apps/frontend/src/shared/i18n/locales/en/settings.json
+++ b/apps/frontend/src/shared/i18n/locales/en/settings.json
@@ -185,6 +185,12 @@
     "comfortable": "Comfortable",
     "large": "Large"
   },
+  "logOrder": {
+    "label": "Log Order",
+    "description": "Choose how logs are displayed in the task detail view",
+    "chronological": "Chronological (oldest first)",
+    "reverseChronological": "Reverse-chronological (newest first)"
+  },
   "general": {
     "otherAgentSettings": "Other Agent Settings",
     "otherAgentSettingsDescription": "Additional agent configuration options",

--- a/apps/frontend/src/shared/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/settings.json
@@ -185,6 +185,12 @@
     "comfortable": "Confortable",
     "large": "Grand"
   },
+  "logOrder": {
+    "label": "Ordre des journaux",
+    "description": "Choisir comment les journaux sont affichés dans la vue détaillée des tâches",
+    "chronological": "Chronologique (plus ancien en premier)",
+    "reverseChronological": "Chronologique inverse (plus récent en premier)"
+  },
   "general": {
     "otherAgentSettings": "Autres paramètres de l'agent",
     "otherAgentSettingsDescription": "Options de configuration supplémentaires de l'agent",

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -269,6 +269,8 @@ export interface AppSettings {
   changelogEmojiLevel?: ChangelogEmojiLevel;
   // UI Scale setting (75-200%, default 100)
   uiScale?: number;
+  // Log order setting for task detail view
+  logOrder?: 'chronological' | 'reverse-chronological';
   // Beta updates opt-in (receive pre-release updates)
   betaUpdates?: boolean;
   // Migration flags (internal use)


### PR DESCRIPTION
## Summary

This PR adds a configurable \"Log Order\" setting for task detail view and fixes inverted log sorting logic.

## Changes

### Features
- Add \"Log Order\" setting in Display Settings with two options:
  - Chronological (oldest first): Oldest logs appear at top, auto-scroll to bottom
  - Reverse-chronological (newest first): Newest logs appear at top, auto-scroll to top
- Add English and French i18n translations

### Bug Fixes
- Fix inverted log order sorting: chronological now correctly shows oldest entries first
  (entries are naturally chronological from append() in backend storage)
- Fix auto-scroll not triggering when new logs arrive by adding phaseLogs to useEffect dependency array
- Fix React key stability issue when toggling log order (was using composite key)

### UX Improvements
- Add max-height and internal scrolling to log order dropdown to prevent viewport expansion
- Change timestamp format to use system locale (toLocaleString) which displays date and time
  according to user's OS settings, making it more readable for European users who prefer 24-hour format
- Use focused selectors for logOrder to avoid unnecessary re-renders

### React Key Implementation

This PR uses a composite key for React stability:
```tsx
key={entry.id || `${entry.timestamp}-${entry.type}-${entry.content}`}
```

For new entries, `entry.id` will be populated by #1722 which adds proper unique IDs
to log entries. The fallback composite key ensures backward compatibility with
existing log files.

## Related PRs

- Follow-up improvement: #1722 (adds unique IDs to log entries)
- #1722 replaces the composite key fallback with proper unique IDs

## Files Changed

- TaskLogs.tsx: fix sorting logic, update timestamp formatting, use focused selectors, add React key stability
- useTaskDetail.ts: add phaseLogs to auto-scroll dependency array
- DisplaySettings.tsx: add log order setting UI, add max-height to SelectContent
- config.ts, settings.ts, i18n files: add logOrder setting type and translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a log ordering setting allowing users to display logs in chronological or reverse-chronological order
  * Auto-scroll behavior now adapts intelligently based on the selected log order preference
  * Enhanced time display with improved date-time formatting

* **Internationalization**
  * Added English and French translations for the new log ordering setting and its options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->