### PR TITLE
fix: correct .auto-claude path mismatch causing discovery phase timeout

### DIFF
--- a/apps/backend/spec/complexity.py
+++ b/apps/backend/spec/complexity.py
@@ -382,7 +382,7 @@ async def run_ai_complexity_assessment(
         context += f"\n**Task Description**: {task_description or 'Not provided'}\n"
 
     # Add project index if available
-    auto_build_index = spec_dir.parent.parent / ".auto-claude" / "project_index.json"
+    auto_build_index = spec_dir.parent.parent / "project_index.json"
     if auto_build_index.exists():
         context += f"\n**Project Index**: Available at {auto_build_index}\n"
 

--- a/apps/backend/spec/complexity.py
+++ b/apps/backend/spec/complexity.py
@@ -382,7 +382,7 @@ async def run_ai_complexity_assessment(
         context += f"\n**Task Description**: {task_description or 'Not provided'}\n"
 
     # Add project index if available
-    auto_build_index = spec_dir.parent.parent / "auto-claude" / "project_index.json"
+    auto_build_index = spec_dir.parent.parent / ".auto-claude" / "project_index.json"
     if auto_build_index.exists():
         context += f"\n**Project Index**: Available at {auto_build_index}\n"
 

--- a/apps/backend/spec/context.py
+++ b/apps/backend/spec/context.py
@@ -34,7 +34,7 @@ def run_context_discovery(
     if context_file.exists():
         return True, "context.json already exists"
 
-    script_path = project_dir / "auto-claude" / "context.py"
+    script_path = project_dir / ".auto-claude" / "context.py"
     if not script_path.exists():
         return False, f"Script not found: {script_path}"
 

--- a/apps/backend/spec/discovery.py
+++ b/apps/backend/spec/discovery.py
@@ -24,7 +24,7 @@ def run_discovery_script(
         (success, output_message)
     """
     spec_index = spec_dir / "project_index.json"
-    auto_build_index = project_dir / "auto-claude" / "project_index.json"
+    auto_build_index = project_dir / ".auto-claude" / "project_index.json"
 
     # Check if project_index already exists
     if auto_build_index.exists() and not spec_index.exists():

--- a/apps/backend/spec/phases/utils.py
+++ b/apps/backend/spec/phases/utils.py
@@ -22,7 +22,7 @@ def run_script(project_dir: Path, script: str, args: list[str]) -> tuple[bool, s
     Returns:
         Tuple of (success: bool, output: str)
     """
-    script_path = project_dir / "auto-claude" / script
+    script_path = project_dir / ".auto-claude" / script
 
     if not script_path.exists():
         return False, f"Script not found: {script_path}"

--- a/apps/backend/spec/pipeline/orchestrator.py
+++ b/apps/backend/spec/pipeline/orchestrator.py
@@ -603,7 +603,7 @@ class SpecOrchestrator:
             The complexity assessment
         """
         project_index = {}
-        auto_build_index = self.project_dir / "auto-claude" / "project_index.json"
+        auto_build_index = self.project_dir / ".auto-claude" / "project_index.json"
         if auto_build_index.exists():
             with open(auto_build_index, encoding="utf-8") as f:
                 project_index = json.load(f)


### PR DESCRIPTION
## Summary

- **Fix path mismatch** between where `project_index.json` is saved (`.auto-claude/`) and where it's read (`auto-claude/` — missing the dot), causing discovery phase to always fall through to a slow subprocess that times out on larger projects
- Affects 5 files in `apps/backend/spec/` — all one-line path corrections from `"auto-claude"` to `".auto-claude"`

## Root Cause

The orchestrator's `_ensure_fresh_project_index()` (line 200) correctly saves the project index to:
```
.auto-claude/project_index.json  ← with dot (correct)
```

But 5 other modules look for it at:
```
auto-claude/project_index.json   ← WITHOUT dot (wrong)
```

Since the cached index is never found at the wrong path, discovery always falls through to running `analyzer.py` as a subprocess with a **300-second timeout**. On larger projects (like skogplattform with node_modules), this subprocess times out every single time.

The `get_specs_dir()` function documents clearly: *"Only `.auto-claude/` is considered an installed auto-claude. The `auto-claude/` folder (if it exists) is SOURCE CODE being developed."*

## Evidence — 9 consecutive failures

Task `051-price-alert-notifications` for skogplattform failed to start **9 consecutive times across 3 sessions** (Feb 5-6). Every attempt takes exactly 300 seconds (the subprocess timeout) and then fails at Phase 1 (PROJECT DISCOVERY):

```
Phase 1: PROJECT DISCOVERY
  → Looking for project_index.json at auto-claude/project_index.json  (WRONG path)
  → Not found → falls through to analyzer.py subprocess
  → subprocess.run(..., timeout=300) → TimeoutExpired
  → "Script timed out"
  → Phase fails → entire spec creation aborts
```

Meanwhile `.auto-claude/project_index.json` exists and is up-to-date — it just wasn't being found.

## When was this introduced?

- **`e309713a`** (Dec 15, 2025) — Original files written with `"auto-claude"` path. At this point the save path was also undotted, so there was no mismatch.
- **`757e5e04`** (Dec 20, 2025) — `_ensure_fresh_project_index()` added to orchestrator with the **correct** `.auto-claude/` save path, but the read paths were never updated → **mismatch introduced here**.

The bug has existed for ~7 weeks but only manifests on larger projects where `analyzer.py` times out.

## Changes

| File | Line | Change |
|------|------|--------|
| `spec/discovery.py` | 27 | `"auto-claude"` → `".auto-claude"` **(primary fix)** |
| `spec/complexity.py` | 385 | `"auto-claude"` → `".auto-claude"` |
| `spec/pipeline/orchestrator.py` | 606 | `"auto-claude"` → `".auto-claude"` |
| `spec/phases/utils.py` | 25 | `"auto-claude"` → `".auto-claude"` |
| `spec/context.py` | 37 | `"auto-claude"` → `".auto-claude"` |

## Verification

After fix, `grep -r '"auto-claude"' apps/backend/spec/` returns **zero matches** — all paths now consistently use `.auto-claude/`.

## Test plan

- [ ] Retry task `051-price-alert-notifications` — discovery phase should find cached index and complete instantly instead of timing out
- [ ] Verify on a fresh project (no cached index) — `analyzer.py` should still run and save to `.auto-claude/`
- [ ] Run backend tests: `cd apps/backend && python -m pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relocated internal auto-generated indexes and discovery scripts into a hidden project directory to tidy the repository layout. Lookup paths were updated across backend spec and pipeline components; this may affect when existing indexes are detected and reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->