### PR TITLE
fix(terminal): push worktree branch to remote with tracking on creation

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
@@ -471,30 +471,38 @@ async function createTerminalWorktree(
       // git push/pull operations work correctly from the worktree.
       // This prevents branches from accumulating local-only commits with
       // no upstream configured, which causes confusion when pushing later.
+      // Check if 'origin' remote exists — silently skip for local-only repos
+      let hasOrigin = false;
       try {
-        // First check if 'origin' remote exists — skip push for local-only repos
         await execFileAsync(getToolPath('git'), ['remote', 'get-url', 'origin'], {
           cwd: projectPath,
           encoding: 'utf-8',
           timeout: 5000,
           env: getIsolatedGitEnv(),
         });
+        hasOrigin = true;
+      } catch {
+        // No origin remote — local-only repo, nothing to push to
+        debugLog('[TerminalWorktree] No origin remote found, skipping push for local-only repo');
+      }
 
-        // Origin exists — push with tracking
-        await execFileAsync(getToolPath('git'), ['push', '-u', 'origin', branchName], {
-          cwd: worktreePath,
-          encoding: 'utf-8',
-          timeout: 30000,
-          env: getIsolatedGitEnv(),
-        });
-        remoteTrackingSetUp = true;
-        debugLog('[TerminalWorktree] Pushed branch to remote with tracking:', branchName);
-      } catch (pushError) {
-        // Worktree was created successfully — don't fail the operation,
-        // but surface a warning so the user knows tracking isn't set up.
-        const message = pushError instanceof Error ? pushError.message : 'Unknown push error';
-        remotePushWarning = `Worktree created but could not push branch to remote: ${message}`;
-        debugLog('[TerminalWorktree] Could not push to remote (worktree still usable):', message);
+      if (hasOrigin) {
+        try {
+          await execFileAsync(getToolPath('git'), ['push', '-u', 'origin', branchName], {
+            cwd: worktreePath,
+            encoding: 'utf-8',
+            timeout: 30000,
+            env: getIsolatedGitEnv(),
+          });
+          remoteTrackingSetUp = true;
+          debugLog('[TerminalWorktree] Pushed branch to remote with tracking:', branchName);
+        } catch (pushError) {
+          // Worktree was created successfully — don't fail the operation,
+          // but surface a warning so the user knows tracking isn't set up.
+          const message = pushError instanceof Error ? pushError.message : 'Unknown push error';
+          remotePushWarning = message;
+          debugLog('[TerminalWorktree] Could not push to remote (worktree still usable):', message);
+        }
       }
     } else {
       // Use async to avoid blocking the main process on large repos.

--- a/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
@@ -451,6 +451,9 @@ async function createTerminalWorktree(
       }
     }
 
+    let remoteTrackingSetUp = false;
+    let remotePushWarning: string | undefined;
+
     if (createGitBranch) {
       // Use --no-track to prevent the new branch from inheriting upstream tracking
       // from the base ref (e.g., origin/main). This ensures users can push with -u
@@ -463,6 +466,36 @@ async function createTerminalWorktree(
         env: getIsolatedGitEnv(),
       });
       debugLog('[TerminalWorktree] Created worktree with branch:', branchName, 'from', baseRef);
+
+      // Push the new branch to remote and set up tracking so subsequent
+      // git push/pull operations work correctly from the worktree.
+      // This prevents branches from accumulating local-only commits with
+      // no upstream configured, which causes confusion when pushing later.
+      try {
+        // First check if 'origin' remote exists — skip push for local-only repos
+        await execFileAsync(getToolPath('git'), ['remote', 'get-url', 'origin'], {
+          cwd: projectPath,
+          encoding: 'utf-8',
+          timeout: 5000,
+          env: getIsolatedGitEnv(),
+        });
+
+        // Origin exists — push with tracking
+        await execFileAsync(getToolPath('git'), ['push', '-u', 'origin', branchName], {
+          cwd: worktreePath,
+          encoding: 'utf-8',
+          timeout: 30000,
+          env: getIsolatedGitEnv(),
+        });
+        remoteTrackingSetUp = true;
+        debugLog('[TerminalWorktree] Pushed branch to remote with tracking:', branchName);
+      } catch (pushError) {
+        // Worktree was created successfully — don't fail the operation,
+        // but surface a warning so the user knows tracking isn't set up.
+        const message = pushError instanceof Error ? pushError.message : 'Unknown push error';
+        remotePushWarning = `Worktree created but could not push branch to remote: ${message}`;
+        debugLog('[TerminalWorktree] Could not push to remote (worktree still usable):', message);
+      }
     } else {
       // Use async to avoid blocking the main process on large repos.
       await execFileAsync(getToolPath('git'), ['worktree', 'add', '--detach', worktreePath, baseRef], {
@@ -490,12 +523,13 @@ async function createTerminalWorktree(
       taskId,
       createdAt: new Date().toISOString(),
       terminalId,
+      remoteTrackingSetUp,
     };
 
     saveWorktreeConfig(projectPath, name, config);
     debugLog('[TerminalWorktree] Saved config for worktree:', name);
 
-    return { success: true, config };
+    return { success: true, config, warning: remotePushWarning };
   } catch (error) {
     debugError('[TerminalWorktree] Error creating worktree:', error);
 

--- a/apps/frontend/src/renderer/components/terminal/CreateWorktreeDialog.tsx
+++ b/apps/frontend/src/renderer/components/terminal/CreateWorktreeDialog.tsx
@@ -231,7 +231,7 @@ export function CreateWorktreeDialog({
         if (result.warning) {
           toast({
             title: t('terminal:worktree.remotePushFailed'),
-            description: t('terminal:worktree.remotePushFailedDescription'),
+            description: result.warning || t('terminal:worktree.remotePushFailedDescription'),
             variant: 'destructive',
           });
         }

--- a/apps/frontend/src/renderer/components/terminal/CreateWorktreeDialog.tsx
+++ b/apps/frontend/src/renderer/components/terminal/CreateWorktreeDialog.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { Combobox } from '../ui/combobox';
+import { useToast } from '../../hooks/use-toast';
 import { buildBranchOptions } from '../../lib/branch-utils';
 import type { Task, TerminalWorktreeConfig, GitBranchDetail } from '../../../shared/types';
 import { useProjectStore } from '../../stores/project-store';
@@ -84,6 +85,7 @@ export function CreateWorktreeDialog({
   onWorktreeCreated,
 }: CreateWorktreeDialogProps) {
   const { t } = useTranslation(['terminal', 'common']);
+  const { toast } = useToast();
   const [name, setName] = useState('');
   const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>();
   const [createGitBranch, setCreateGitBranch] = useState(true);
@@ -225,6 +227,14 @@ export function CreateWorktreeDialog({
         setName('');
         setSelectedTaskId(undefined);
         setCreateGitBranch(true);
+        // Notify user if remote tracking could not be set up
+        if (result.warning) {
+          toast({
+            title: t('terminal:worktree.remotePushFailed'),
+            description: t('terminal:worktree.remotePushFailedDescription'),
+            variant: 'destructive',
+          });
+        }
       } else {
         setError(result.error || t('common:errors.generic'));
       }

--- a/apps/frontend/src/shared/i18n/locales/en/terminal.json
+++ b/apps/frontend/src/shared/i18n/locales/en/terminal.json
@@ -40,6 +40,8 @@
     "alreadyExists": "A worktree with this name already exists",
     "deleteTitle": "Delete Worktree?",
     "deleteDescription": "This will permanently delete the worktree and its branch. Any uncommitted changes will be lost.",
-    "detached": "(detached)"
+    "detached": "(detached)",
+    "remotePushFailed": "Remote Tracking Not Set Up",
+    "remotePushFailedDescription": "Worktree created but the branch could not be pushed to remote. You may need to run git push -u manually."
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/terminal.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/terminal.json
@@ -40,6 +40,8 @@
     "alreadyExists": "Un worktree avec ce nom existe deja",
     "deleteTitle": "Supprimer le Worktree?",
     "deleteDescription": "Ceci supprimera definitivement le worktree et sa branche. Les modifications non committées seront perdues.",
-    "detached": "(détaché)"
+    "detached": "(détaché)",
+    "remotePushFailed": "Suivi distant non configure",
+    "remotePushFailedDescription": "Le worktree a ete cree mais la branche n'a pas pu etre poussee vers le depot distant. Vous devrez peut-etre executer git push -u manuellement."
   }
 }

--- a/apps/frontend/src/shared/types/terminal.ts
+++ b/apps/frontend/src/shared/types/terminal.ts
@@ -219,6 +219,8 @@ export interface TerminalWorktreeConfig {
   createdAt: string;
   /** Terminal ID this worktree is associated with */
   terminalId: string;
+  /** Whether the branch was pushed to remote with tracking set up */
+  remoteTrackingSetUp?: boolean;
 }
 
 /**
@@ -252,6 +254,8 @@ export interface TerminalWorktreeResult {
   success: boolean;
   config?: TerminalWorktreeConfig;
   error?: string;
+  /** Warning when worktree was created but remote push failed */
+  warning?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Terminal worktree branches were created with `--no-track` and never pushed to remote, leaving them with no upstream configured
- After `git worktree add`, now checks for an `origin` remote and runs `git push -u origin terminal/{name}` to establish proper tracking
- Push failures are non-fatal — the worktree is still created but a warning is surfaced to the caller

## Test plan
- [ ] Create a terminal worktree in a project with a remote — verify branch appears on remote with tracking set up
- [ ] Create a terminal worktree in a local-only repo (no remote) — verify worktree creation still succeeds with no error
- [ ] Create a terminal worktree with no network — verify worktree creation succeeds with warning returned
- [ ] Verify `git push` from inside a new terminal worktree works without needing `--set-upstream`
- [ ] Run `npm run typecheck` and `npm test` — both pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree creation now tries to push new branches to the remote and enable tracking; the worktree remains usable if the push fails.
  * If a remote push fails, users receive a warning and a destructive toast with a localized message.
  * The worktree creation result now saves a flag indicating whether remote tracking was set up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->