### PR TITLE
fix(terminal): use each terminal's cwd for invoke Claude all button

### DIFF
--- a/apps/frontend/src/renderer/components/TerminalGrid.tsx
+++ b/apps/frontend/src/renderer/components/TerminalGrid.tsx
@@ -263,7 +263,7 @@ export function TerminalGrid({ projectPath, onNewTaskClick, isActive = false }: 
     terminals.forEach((terminal) => {
       if (terminal.status === 'running' && !terminal.isClaudeMode) {
         setClaudeMode(terminal.id, true);
-        window.electronAPI.invokeClaudeInTerminal(terminal.id, projectPath);
+        window.electronAPI.invokeClaudeInTerminal(terminal.id, terminal.cwd || projectPath);
       }
     });
   }, [terminals, setClaudeMode, projectPath]);


### PR DESCRIPTION
## Summary
- The "Invoke Claude All" button was passing `projectPath` (project root) to every terminal, ignoring each terminal's current working directory
- Now uses `terminal.cwd || projectPath`, matching the single-terminal invoke button behavior in `Terminal.tsx`

## Test plan
- [x] TypeScript type check passes
- [x] Biome CI passes (0 errors)
- [x] All 2822 Vitest tests pass
- [x] Security, logic, codebase-fit, cross-platform reviews clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Claude invocations now properly respect each terminal's current working directory, ensuring commands and operations execute in the correct context for that specific terminal session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->