### PR TITLE
feat: update Opus model to Claude Opus 4.6

### DIFF
--- a/apps/backend/phase_config.py
+++ b/apps/backend/phase_config.py
@@ -13,7 +13,7 @@ from typing import Literal, TypedDict
 
 # Model shorthand to full model ID mapping
 MODEL_ID_MAP: dict[str, str] = {
-    "opus": "claude-opus-4-5-20251101",
+    "opus": "claude-opus-4-6",
     "sonnet": "claude-sonnet-4-5-20250929",
     "haiku": "claude-haiku-4-5-20251001",
 }

--- a/apps/frontend/src/shared/constants/models.ts
+++ b/apps/frontend/src/shared/constants/models.ts
@@ -10,14 +10,14 @@ import type { AgentProfile, PhaseModelConfig, FeatureModelConfig, FeatureThinkin
 // ============================================
 
 export const AVAILABLE_MODELS = [
-  { value: 'opus', label: 'Claude Opus 4.5' },
+  { value: 'opus', label: 'Claude Opus 4.6' },
   { value: 'sonnet', label: 'Claude Sonnet 4.5' },
   { value: 'haiku', label: 'Claude Haiku 4.5' }
 ] as const;
 
 // Maps model shorthand to actual Claude model IDs
 export const MODEL_ID_MAP: Record<string, string> = {
-  opus: 'claude-opus-4-5-20251101',
+  opus: 'claude-opus-4-6',
   sonnet: 'claude-sonnet-4-5-20250929',
   haiku: 'claude-haiku-4-5-20251001'
 } as const;


### PR DESCRIPTION
## Summary

Update the Opus model identifier to the newly released **Claude Opus 4.6** across backend and frontend.

## Changes

### Backend (`apps/backend/phase_config.py`)
- Updated `MODEL_ID_MAP["opus"]` from `claude-opus-4-5-20251101` to `claude-opus-4-6`

### Frontend (`apps/frontend/src/shared/constants/models.ts`)
- Updated `MODEL_ID_MAP.opus` from `claude-opus-4-5-20251101` to `claude-opus-4-6`
- Updated `AVAILABLE_MODELS` label from "Claude Opus 4.5" to "Claude Opus 4.6"

## Testing

- Existing tests in `tests/test_model_resolution.py` use `MODEL_ID_MAP["opus"]` references (not hardcoded model ID strings), so they will pass without modification
- Environment variable overrides (`ANTHROPIC_DEFAULT_OPUS_MODEL`) continue to work as documented

## Context

Anthropic released Claude Opus 4.6 as the latest model in the Claude 4.5 family. The model string `claude-opus-4-6` is now the correct identifier for the most advanced Claude model available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Claude Opus model to version 4.6, providing access to the latest improvements and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->