### PR TITLE
fix(title-generator): add production path resolution for backend source

### DIFF
--- a/apps/frontend/src/main/terminal-name-generator.ts
+++ b/apps/frontend/src/main/terminal-name-generator.ts
@@ -1,16 +1,11 @@
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
 import { spawn } from 'child_process';
-import { app } from 'electron';
-
-// ESM-compatible __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 import { EventEmitter } from 'events';
 import { detectRateLimit, createSDKRateLimitInfo, getBestAvailableProfileEnv } from './rate-limit-detector';
 import { parsePythonCommand } from './python-detector';
 import { pythonEnvManager } from './python-env-manager';
+import { getEffectiveSourcePath } from './updater/path-resolver';
 
 /**
  * Debug logging - only logs when DEBUG=true or in development mode
@@ -51,35 +46,16 @@ export class TerminalNameGenerator extends EventEmitter {
       return this.autoBuildSourcePath;
     }
 
-    // In packaged app, check userData override first (consistent with path-resolver.ts)
-    if (app.isPackaged) {
-      // Check for user-updated backend source first (takes priority over bundled)
-      const overridePath = path.join(app.getPath('userData'), 'backend-source');
-      if (existsSync(overridePath) && existsSync(path.join(overridePath, 'runners', 'spec_runner.py'))) {
-        debug('Using user-updated backend from userData:', overridePath);
-        return overridePath;
-      }
-      // Fall back to bundled backend in resources
-      const resourcesPath = path.join(process.resourcesPath, 'backend');
-      if (existsSync(resourcesPath) && existsSync(path.join(resourcesPath, 'runners', 'spec_runner.py'))) {
-        debug('Using bundled backend from resources:', resourcesPath);
-        return resourcesPath;
-      }
+    // Use shared path resolver which handles:
+    // 1. User settings (autoBuildPath)
+    // 2. userData override (backend-source) for user-updated backend
+    // 3. Bundled backend (process.resourcesPath/backend)
+    // 4. Development paths
+    const effectivePath = getEffectiveSourcePath();
+    if (existsSync(effectivePath) && existsSync(path.join(effectivePath, 'runners', 'spec_runner.py'))) {
+      return effectivePath;
     }
 
-    // Development mode paths
-    const possiblePaths = [
-      // Apps structure: from out/main -> apps/backend
-      path.resolve(__dirname, '..', '..', '..', 'backend'),
-      path.resolve(app.getAppPath(), '..', 'backend'),
-      path.resolve(process.cwd(), 'apps', 'backend')
-    ];
-
-    for (const p of possiblePaths) {
-      if (existsSync(p) && existsSync(path.join(p, 'runners', 'spec_runner.py'))) {
-        return p;
-      }
-    }
     return null;
   }
 

--- a/apps/frontend/src/main/title-generator.ts
+++ b/apps/frontend/src/main/title-generator.ts
@@ -1,18 +1,13 @@
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
 import { spawn } from 'child_process';
-import { app } from 'electron';
-
-// ESM-compatible __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 import { EventEmitter } from 'events';
 import { detectRateLimit, createSDKRateLimitInfo, getBestAvailableProfileEnv } from './rate-limit-detector';
 import { parsePythonCommand, getValidatedPythonPath } from './python-detector';
 import { getConfiguredPythonPath } from './python-env-manager';
 import { getAPIProfileEnv } from './services/profile';
 import { getOAuthModeClearVars } from './agent/env-utils';
+import { getEffectiveSourcePath } from './updater/path-resolver';
 
 /**
  * Debug logging - only logs when DEBUG=true or in development mode
@@ -67,32 +62,16 @@ export class TitleGenerator extends EventEmitter {
       return this.autoBuildSourcePath;
     }
 
-    // In packaged app, check userData override first (user-updated backend), then bundled
-    if (app.isPackaged) {
-      const overridePath = path.join(app.getPath('userData'), 'backend-source');
-      if (existsSync(overridePath) && existsSync(path.join(overridePath, 'runners', 'spec_runner.py'))) {
-        debug('Using user-updated backend from userData:', overridePath);
-        return overridePath;
-      }
-      const resourcesPath = path.join(process.resourcesPath, 'backend');
-      if (existsSync(resourcesPath) && existsSync(path.join(resourcesPath, 'runners', 'spec_runner.py'))) {
-        debug('Using bundled backend from resources:', resourcesPath);
-        return resourcesPath;
-      }
+    // Use shared path resolver which handles:
+    // 1. User settings (autoBuildPath)
+    // 2. userData override (backend-source) for user-updated backend
+    // 3. Bundled backend (process.resourcesPath/backend)
+    // 4. Development paths
+    const effectivePath = getEffectiveSourcePath();
+    if (existsSync(effectivePath) && existsSync(path.join(effectivePath, 'runners', 'spec_runner.py'))) {
+      return effectivePath;
     }
 
-    // Development mode paths
-    const possiblePaths = [
-      path.resolve(__dirname, '..', '..', '..', 'backend'),
-      path.resolve(app.getAppPath(), '..', 'backend'),
-      path.resolve(process.cwd(), 'apps', 'backend')
-    ];
-
-    for (const p of possiblePaths) {
-      if (existsSync(p) && existsSync(path.join(p, 'runners', 'spec_runner.py'))) {
-        return p;
-      }
-    }
     return null;
   }
 

--- a/apps/frontend/src/main/title-generator.ts
+++ b/apps/frontend/src/main/title-generator.ts
@@ -67,8 +67,22 @@ export class TitleGenerator extends EventEmitter {
       return this.autoBuildSourcePath;
     }
 
+    // In packaged app, check userData override first (user-updated backend), then bundled
+    if (app.isPackaged) {
+      const overridePath = path.join(app.getPath('userData'), 'backend-source');
+      if (existsSync(overridePath) && existsSync(path.join(overridePath, 'runners', 'spec_runner.py'))) {
+        debug('Using user-updated backend from userData:', overridePath);
+        return overridePath;
+      }
+      const resourcesPath = path.join(process.resourcesPath, 'backend');
+      if (existsSync(resourcesPath) && existsSync(path.join(resourcesPath, 'runners', 'spec_runner.py'))) {
+        debug('Using bundled backend from resources:', resourcesPath);
+        return resourcesPath;
+      }
+    }
+
+    // Development mode paths
     const possiblePaths = [
-      // Apps structure: from out/main -> apps/backend
       path.resolve(__dirname, '..', '..', '..', 'backend'),
       path.resolve(app.getAppPath(), '..', 'backend'),
       path.resolve(process.cwd(), 'apps', 'backend')


### PR DESCRIPTION
## Summary

AI task title generation (using Claude Haiku) silently fails in packaged/production builds because `getAutoBuildSourcePath()` in `title-generator.ts` only checked development-mode relative paths.

## Problem

When the app is packaged, the Python backend is bundled at `process.resourcesPath/backend`, but the title generator only checked dev-mode paths (`__dirname/../../..`, `app.getAppPath()/../backend`, `cwd/apps/backend`). When it couldn't find the backend, `generateTitle()` returned `null` and the UI fell back to using the first line of the task description as the title.

Every other service that spawns Python subprocesses already handles production paths correctly (`agent-process.ts`, `terminal-name-generator.ts`, `insights/config.ts`, `settings-handlers.ts`) — the title generator was the only one left behind.

## Solution

Added `app.isPackaged` check to `getAutoBuildSourcePath()` that resolves production paths before falling back to dev-mode paths:

1. **`userData/backend-source`** — user-updated backend override (checked first)
2. **`process.resourcesPath/backend`** — bundled backend in the packaged app

This mirrors the exact pattern from `terminal-name-generator.ts` (the closest analog — both are lightweight AI generation services that spawn Python subprocesses).

## Changes

- `apps/frontend/src/main/title-generator.ts` — Added production path resolution (+15 lines)

## Testing

- [x] Existing tests pass (3047 passed)
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [ ] Tested in production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for user-provided backend sources: custom backends are now detected more reliably and take precedence over bundled versions.

* **Bug Fixes**
  * Reduced failures and inconsistencies when locating custom or development backend installations, making backend updates and local development smoother.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->