### PR TITLE
fix(plan-files): use atomic writes to prevent 0-byte corruption

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
@@ -18,27 +18,12 @@
  */
 
 import path from 'path';
-import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from 'fs';
+import { readFileSync, mkdirSync } from 'fs';
 import { AUTO_BUILD_PATHS, getSpecsDir } from '../../../shared/constants';
 import type { TaskStatus, Project, Task } from '../../../shared/types';
 import { projectStore } from '../../project-store';
 import type { TaskEventPayload } from '../../agent/task-event-schema';
-
-/**
- * Atomic write: write to a temp file then rename to prevent corruption.
- * If the process crashes between truncate and write, a bare writeFileSync
- * leaves a 0-byte file. Rename is atomic on POSIX and near-atomic on Windows.
- */
-function atomicWriteFileSync(filePath: string, data: string): void {
-  const tempPath = `${filePath}.${process.pid}.tmp`;
-  try {
-    writeFileSync(tempPath, data, 'utf-8');
-    renameSync(tempPath, filePath);
-  } catch (err) {
-    try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
-    throw err;
-  }
-}
+import { writeFileAtomicSync } from '../../utils/atomic-file';
 
 // In-memory locks for plan file operations
 // Key: plan file path, Value: Promise chain for serializing operations
@@ -128,7 +113,7 @@ export async function persistPlanStatus(planPath: string, status: TaskStatus, pr
       plan.planStatus = mapStatusToPlanStatus(status);
       plan.updated_at = new Date().toISOString();
 
-      atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+      writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
       console.warn(`[plan-file-utils] Successfully persisted status: ${status} to implementation_plan.json`);
 
       // Invalidate tasks cache since status changed
@@ -184,7 +169,7 @@ export function persistPlanStatusSync(planPath: string, status: TaskStatus, proj
     plan.planStatus = mapStatusToPlanStatus(status);
     plan.updated_at = new Date().toISOString();
 
-    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+    writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
 
     // Invalidate tasks cache since status changed
     if (projectId) {
@@ -221,7 +206,7 @@ export function persistPlanLastEventSync(planPath: string, event: TaskEventPaylo
     };
     plan.updated_at = new Date().toISOString();
 
-    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+    writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
     return true;
   } catch (err) {
     if (isFileNotFoundError(err)) {
@@ -280,7 +265,7 @@ export function persistPlanStatusAndReasonSync(
     }
     plan.updated_at = new Date().toISOString();
 
-    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+    writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
 
     if (projectId) {
       projectStore.invalidateTasksCache(projectId);
@@ -343,7 +328,7 @@ export function persistPlanPhaseSync(
 
     plan.updated_at = new Date().toISOString();
 
-    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+    writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
 
     if (projectId) {
       projectStore.invalidateTasksCache(projectId);
@@ -378,7 +363,7 @@ export async function updatePlanFile<T extends Record<string, unknown>>(
       // Add updated_at timestamp - use type assertion since T extends Record<string, unknown>
       (updatedPlan as Record<string, unknown>).updated_at = new Date().toISOString();
 
-      atomicWriteFileSync(planPath, JSON.stringify(updatedPlan, null, 2));
+      writeFileAtomicSync(planPath, JSON.stringify(updatedPlan, null, 2));
       console.warn(`[plan-file-utils] Successfully updated implementation_plan.json`);
       return updatedPlan;
     } catch (err) {
@@ -445,7 +430,7 @@ export async function createPlanIfNotExists(
       }
     }
 
-    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+    writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
   });
 }
 
@@ -492,7 +477,7 @@ export async function resetStuckSubtasks(planPath: string, projectId?: string): 
       // Only write if we actually reset something
       if (resetCount > 0) {
         plan.updated_at = new Date().toISOString();
-        atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
+        writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
         console.log(`[plan-file-utils] Successfully reset ${resetCount} stuck subtask(s) in implementation_plan.json`);
 
         // Invalidate tasks cache since subtask status changed
@@ -546,7 +531,7 @@ export function updateTaskMetadataPrUrl(metadataPath: string, prUrl: string): bo
     mkdirSync(path.dirname(metadataPath), { recursive: true });
 
     // Write back
-    writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
+    writeFileAtomicSync(metadataPath, JSON.stringify(metadata, null, 2));
     return true;
   } catch (err) {
     console.warn(`[plan-file-utils] Could not update metadata at ${metadataPath}:`, err);

--- a/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
@@ -24,6 +24,22 @@ import type { TaskStatus, Project, Task } from '../../../shared/types';
 import { projectStore } from '../../project-store';
 import type { TaskEventPayload } from '../../agent/task-event-schema';
 
+/**
+ * Atomic write: write to a temp file then rename to prevent corruption.
+ * If the process crashes between truncate and write, a bare writeFileSync
+ * leaves a 0-byte file. Rename is atomic on POSIX and near-atomic on Windows.
+ */
+function atomicWriteFileSync(filePath: string, data: string): void {
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    writeFileSync(tempPath, data, 'utf-8');
+    renameSync(tempPath, filePath);
+  } catch (err) {
+    try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
+    throw err;
+  }
+}
+
 // In-memory locks for plan file operations
 // Key: plan file path, Value: Promise chain for serializing operations
 const planLocks = new Map<string, Promise<void>>();
@@ -112,7 +128,7 @@ export async function persistPlanStatus(planPath: string, status: TaskStatus, pr
       plan.planStatus = mapStatusToPlanStatus(status);
       plan.updated_at = new Date().toISOString();
 
-      writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+      atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
       console.warn(`[plan-file-utils] Successfully persisted status: ${status} to implementation_plan.json`);
 
       // Invalidate tasks cache since status changed
@@ -168,7 +184,7 @@ export function persistPlanStatusSync(planPath: string, status: TaskStatus, proj
     plan.planStatus = mapStatusToPlanStatus(status);
     plan.updated_at = new Date().toISOString();
 
-    writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
 
     // Invalidate tasks cache since status changed
     if (projectId) {
@@ -205,7 +221,7 @@ export function persistPlanLastEventSync(planPath: string, event: TaskEventPaylo
     };
     plan.updated_at = new Date().toISOString();
 
-    writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
     return true;
   } catch (err) {
     if (isFileNotFoundError(err)) {
@@ -264,7 +280,7 @@ export function persistPlanStatusAndReasonSync(
     }
     plan.updated_at = new Date().toISOString();
 
-    writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
 
     if (projectId) {
       projectStore.invalidateTasksCache(projectId);
@@ -327,7 +343,7 @@ export function persistPlanPhaseSync(
 
     plan.updated_at = new Date().toISOString();
 
-    writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
 
     if (projectId) {
       projectStore.invalidateTasksCache(projectId);
@@ -362,7 +378,7 @@ export async function updatePlanFile<T extends Record<string, unknown>>(
       // Add updated_at timestamp - use type assertion since T extends Record<string, unknown>
       (updatedPlan as Record<string, unknown>).updated_at = new Date().toISOString();
 
-      writeFileSync(planPath, JSON.stringify(updatedPlan, null, 2), 'utf-8');
+      atomicWriteFileSync(planPath, JSON.stringify(updatedPlan, null, 2));
       console.warn(`[plan-file-utils] Successfully updated implementation_plan.json`);
       return updatedPlan;
     } catch (err) {
@@ -429,7 +445,7 @@ export async function createPlanIfNotExists(
       }
     }
 
-    writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+    atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
   });
 }
 
@@ -476,16 +492,7 @@ export async function resetStuckSubtasks(planPath: string, projectId?: string): 
       // Only write if we actually reset something
       if (resetCount > 0) {
         plan.updated_at = new Date().toISOString();
-        const content = JSON.stringify(plan, null, 2);
-        // Atomic write: write to temp file then rename to prevent corruption on crash
-        const tempPath = `${planPath}.${process.pid}.tmp`;
-        try {
-          writeFileSync(tempPath, content, 'utf-8');
-          renameSync(tempPath, planPath);
-        } catch (writeError) {
-          try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
-          throw writeError;
-        }
+        atomicWriteFileSync(planPath, JSON.stringify(plan, null, 2));
         console.log(`[plan-file-utils] Successfully reset ${resetCount} stuck subtask(s) in implementation_plan.json`);
 
         // Invalidate tasks cache since subtask status changed

--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, renameSync, unlinkSync, Dirent } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, Dirent } from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import type { Project, ProjectSettings, Task, TaskStatus, TaskMetadata, ImplementationPlan, ReviewReason, PlanSubtask, KanbanPreferences, ExecutionPhase } from '../shared/types';
@@ -8,6 +8,7 @@ import { getAutoBuildPath, isInitialized } from './project-initializer';
 import { getTaskWorktreeDir } from './worktree-paths';
 import { findAllSpecPaths } from './utils/spec-path-helpers';
 import { ensureAbsolutePath } from './utils/path-helpers';
+import { writeFileAtomicSync } from './utils/atomic-file';
 
 interface TabState {
   openProjectIds: string[];
@@ -631,14 +632,7 @@ export class ProjectStore {
       };
       try {
         // Atomic write to prevent 0-byte corruption on crash
-        const tempPath = `${planPath}.${process.pid}.tmp`;
-        try {
-          writeFileSync(tempPath, JSON.stringify(correctedPlan, null, 2), 'utf-8');
-          renameSync(tempPath, planPath);
-        } catch (atomicErr) {
-          try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
-          throw atomicErr;
-        }
+        writeFileAtomicSync(planPath, JSON.stringify(correctedPlan, null, 2));
         // Write succeeded — apply mutations to the in-memory plan so the rest of
         // loadTasksFromSpecsDir sees the corrected values (e.g., executionProgress)
         Object.assign(plan, correctedPlan);

--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, Dirent } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, renameSync, unlinkSync, Dirent } from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import type { Project, ProjectSettings, Task, TaskStatus, TaskMetadata, ImplementationPlan, ReviewReason, PlanSubtask, KanbanPreferences, ExecutionPhase } from '../shared/types';
@@ -630,7 +630,15 @@ export class ProjectStore {
         executionPhase: 'complete'
       };
       try {
-        writeFileSync(planPath, JSON.stringify(correctedPlan, null, 2), 'utf-8');
+        // Atomic write to prevent 0-byte corruption on crash
+        const tempPath = `${planPath}.${process.pid}.tmp`;
+        try {
+          writeFileSync(tempPath, JSON.stringify(correctedPlan, null, 2), 'utf-8');
+          renameSync(tempPath, planPath);
+        } catch (atomicErr) {
+          try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
+          throw atomicErr;
+        }
         // Write succeeded — apply mutations to the in-memory plan so the rest of
         // loadTasksFromSpecsDir sees the corrected values (e.g., executionProgress)
         Object.assign(plan, correctedPlan);

--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, Dirent } from 'fs';
+import { readFileSync, existsSync, mkdirSync, readdirSync, Dirent } from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import type { Project, ProjectSettings, Task, TaskStatus, TaskMetadata, ImplementationPlan, ReviewReason, PlanSubtask, KanbanPreferences, ExecutionPhase } from '../shared/types';
@@ -79,7 +79,7 @@ export class ProjectStore {
    * Save store to disk
    */
   private save(): void {
-    writeFileSync(this.storePath, JSON.stringify(this.data, null, 2), 'utf-8');
+    writeFileAtomicSync(this.storePath, JSON.stringify(this.data, null, 2));
   }
 
   /**
@@ -800,7 +800,7 @@ export class ProjectStore {
             metadata.archivedInVersion = version;
           }
 
-          writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
+          writeFileAtomicSync(metadataPath, JSON.stringify(metadata, null, 2));
         } catch (error) {
           console.error(`[ProjectStore] archiveTasks: Failed to archive task ${taskId} at ${specPath}:`, error);
           hasErrors = true;
@@ -858,7 +858,7 @@ export class ProjectStore {
 
           delete metadata.archivedAt;
           delete metadata.archivedInVersion;
-          writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
+          writeFileAtomicSync(metadataPath, JSON.stringify(metadata, null, 2));
         } catch (error) {
           console.error(`[ProjectStore] unarchiveTasks: Failed to unarchive task ${taskId} at ${specPath}:`, error);
           hasErrors = true;

--- a/apps/frontend/src/main/utils/__tests__/atomic-file.test.ts
+++ b/apps/frontend/src/main/utils/__tests__/atomic-file.test.ts
@@ -3,10 +3,11 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import {
   writeFileAtomic,
+  writeFileAtomicSync,
   writeFileWithRetry,
   readFileWithRetry,
   writeJsonAtomic,
@@ -432,6 +433,99 @@ describe('writeJsonWithRetry', () => {
 
       const result = JSON.parse(await readFile(filePath, 'utf-8'));
       expect(result).toEqual(data);
+    });
+  });
+});
+
+describe('writeFileAtomicSync', () => {
+  beforeEach(async () => {
+    if (existsSync(TEST_DIR)) {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    }
+    await mkdir(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(TEST_DIR)) {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  describe('basic operations', () => {
+    it('should write a new file atomically', () => {
+      const filePath = path.join(TEST_DIR, 'sync-test.txt');
+      const content = 'Hello, sync!';
+
+      writeFileAtomicSync(filePath, content);
+
+      const result = readFileSync(filePath, 'utf-8');
+      expect(result).toBe(content);
+    });
+
+    it('should overwrite an existing file atomically', () => {
+      const filePath = path.join(TEST_DIR, 'sync-existing.txt');
+      writeFileSync(filePath, 'Initial content', 'utf-8');
+
+      writeFileAtomicSync(filePath, 'New content');
+
+      const result = readFileSync(filePath, 'utf-8');
+      expect(result).toBe('New content');
+    });
+
+    it('should write Buffer data', () => {
+      const filePath = path.join(TEST_DIR, 'sync-buffer.bin');
+      const buffer = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+
+      writeFileAtomicSync(filePath, buffer);
+
+      const result = readFileSync(filePath);
+      expect(result).toEqual(buffer);
+    });
+
+    it('should resolve relative paths', () => {
+      const absolutePath = path.join(TEST_DIR, 'sync-resolve.txt');
+      // Use a relative path that resolves to the same location
+      const relativePath = path.relative(process.cwd(), absolutePath);
+
+      writeFileAtomicSync(relativePath, 'resolved content');
+
+      const result = readFileSync(absolutePath, 'utf-8');
+      expect(result).toBe('resolved content');
+    });
+  });
+
+  describe('temp file cleanup', () => {
+    it('should not leave temp files after successful write', () => {
+      const filePath = path.join(TEST_DIR, 'sync-no-temp.txt');
+
+      writeFileAtomicSync(filePath, 'content');
+
+      const files = fsPromises.readdir(TEST_DIR);
+      return files.then(f => {
+        const tempFiles = f.filter(name => name.includes('.tmp.'));
+        expect(tempFiles).toHaveLength(0);
+      });
+    });
+
+    it('should clean up temp file on write error', () => {
+      // Try to write to a path where the directory doesn't exist
+      const filePath = path.join(TEST_DIR, 'nonexistent-dir', 'file.txt');
+
+      expect(() => writeFileAtomicSync(filePath, 'content')).toThrow();
+
+      // Verify no temp files left in TEST_DIR
+      return fsPromises.readdir(TEST_DIR).then(f => {
+        const tempFiles = f.filter(name => name.includes('.tmp.'));
+        expect(tempFiles).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when directory does not exist', () => {
+      const filePath = path.join(TEST_DIR, 'no', 'such', 'dir', 'file.txt');
+
+      expect(() => writeFileAtomicSync(filePath, 'content')).toThrow();
     });
   });
 });

--- a/apps/frontend/src/main/utils/__tests__/atomic-file.test.ts
+++ b/apps/frontend/src/main/utils/__tests__/atomic-file.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
 import path from 'path';
 import {
   writeFileAtomic,
@@ -500,24 +500,23 @@ describe('writeFileAtomicSync', () => {
 
       writeFileAtomicSync(filePath, 'content');
 
-      const files = fsPromises.readdir(TEST_DIR);
-      return files.then(f => {
-        const tempFiles = f.filter(name => name.includes('.tmp.'));
-        expect(tempFiles).toHaveLength(0);
-      });
+      const files = readdirSync(TEST_DIR);
+      const tempFiles = files.filter(name => name.includes('.tmp.'));
+      expect(tempFiles).toHaveLength(0);
     });
 
-    it('should clean up temp file on write error', () => {
-      // Try to write to a path where the directory doesn't exist
-      const filePath = path.join(TEST_DIR, 'nonexistent-dir', 'file.txt');
+    it('should clean up temp file when rename fails', () => {
+      // Create a subdirectory as the "target" — renameSync will fail because
+      // you can't atomically replace a directory with a file
+      const dirTarget = path.join(TEST_DIR, 'is-a-dir');
+      mkdirSync(dirTarget);
 
-      expect(() => writeFileAtomicSync(filePath, 'content')).toThrow();
+      expect(() => writeFileAtomicSync(dirTarget, 'content')).toThrow();
 
-      // Verify no temp files left in TEST_DIR
-      return fsPromises.readdir(TEST_DIR).then(f => {
-        const tempFiles = f.filter(name => name.includes('.tmp.'));
-        expect(tempFiles).toHaveLength(0);
-      });
+      // Verify temp file was cleaned up (it was created in TEST_DIR)
+      const files = readdirSync(TEST_DIR);
+      const tempFiles = files.filter(name => name.includes('.tmp.'));
+      expect(tempFiles).toHaveLength(0);
     });
   });
 

--- a/apps/frontend/src/main/utils/atomic-file.ts
+++ b/apps/frontend/src/main/utils/atomic-file.ts
@@ -89,6 +89,9 @@ export async function writeFileAtomic(
  * Write data to file atomically using temp file and rename.
  * Uses randomBytes for collision-safe temp file naming.
  *
+ * NOTE: Unlike writeFileAtomic, this function does NOT create parent directories.
+ * The caller must ensure the target directory exists.
+ *
  * @param filepath - Target file path
  * @param data - Data to write (string or Buffer)
  * @param encoding - File encoding (default: 'utf-8')

--- a/apps/frontend/src/main/utils/atomic-file.ts
+++ b/apps/frontend/src/main/utils/atomic-file.ts
@@ -15,7 +15,7 @@
  */
 
 import { mkdir, rename, unlink, writeFile, readFile } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, writeFileSync, renameSync, unlinkSync } from 'fs';
 import path from 'path';
 import { randomBytes } from 'crypto';
 
@@ -80,6 +80,33 @@ export async function writeFileAtomic(
       console.warn(`Failed to cleanup temp file ${tempPath}:`, cleanupError);
     }
     throw error;
+  }
+}
+
+/**
+ * Synchronous variant of writeFileAtomic.
+ *
+ * Write data to file atomically using temp file and rename.
+ * Uses randomBytes for collision-safe temp file naming.
+ *
+ * @param filepath - Target file path
+ * @param data - Data to write (string or Buffer)
+ * @param encoding - File encoding (default: 'utf-8')
+ */
+export function writeFileAtomicSync(
+  filepath: string,
+  data: string | Buffer,
+  encoding: BufferEncoding = 'utf-8'
+): void {
+  const dir = path.dirname(filepath);
+  const tempSuffix = randomBytes(8).toString('hex');
+  const tempPath = path.join(dir, `.${path.basename(filepath)}.tmp.${tempSuffix}`);
+  try {
+    writeFileSync(tempPath, data, encoding);
+    renameSync(tempPath, filepath);
+  } catch (err) {
+    try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
+    throw err;
   }
 }
 

--- a/apps/frontend/src/main/utils/atomic-file.ts
+++ b/apps/frontend/src/main/utils/atomic-file.ts
@@ -98,12 +98,13 @@ export function writeFileAtomicSync(
   data: string | Buffer,
   encoding: BufferEncoding = 'utf-8'
 ): void {
-  const dir = path.dirname(filepath);
+  const absolutePath = path.resolve(filepath);
+  const dir = path.dirname(absolutePath);
   const tempSuffix = randomBytes(8).toString('hex');
-  const tempPath = path.join(dir, `.${path.basename(filepath)}.tmp.${tempSuffix}`);
+  const tempPath = path.join(dir, `.${path.basename(absolutePath)}.tmp.${tempSuffix}`);
   try {
     writeFileSync(tempPath, data, encoding);
-    renameSync(tempPath, filepath);
+    renameSync(tempPath, absolutePath);
   } catch (err) {
     try { unlinkSync(tempPath); } catch { /* ignore cleanup */ }
     throw err;


### PR DESCRIPTION
## Summary
- `implementation_plan.json` for spec 211 was found empty (0 bytes), causing "Unexpected end of JSON input" parse errors
- Root cause: `writeFileSync` truncates the file to 0 bytes before writing content — if the process crashes mid-write, the file is left empty
- Replaced all bare `writeFileSync` calls for plan files with atomic write-to-temp-then-rename pattern in `plan-file-utils.ts` and `project-store.ts`
- Restored the corrupted file from the intact worktree copy

## Test plan
- [ ] Verify existing tasks load correctly after the change
- [ ] Verify new task creation still works (plan file created properly)
- [ ] Verify task status transitions persist correctly
- [ ] Kill the app mid-task to confirm plan files are not corrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file persistence reliability by switching synchronous writes to atomic operations to reduce risk of 0-byte or partial corruption during crashes; read paths and locking semantics remain unchanged.

* **Chores**
  * Centralized and introduced a synchronous atomic-write utility and migrated internal write paths; public APIs and signatures unchanged.

* **Tests**
  * Added tests for synchronous atomic-write behavior, temp-file cleanup, overwrite cases, path resolution, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->