### PR TITLE
fix(github): use UTC timestamps for reviewed_at to fix comment detection

### DIFF
--- a/apps/backend/runners/github/models.py
+++ b/apps/backend/runners/github/models.py
@@ -24,7 +24,7 @@ except (ImportError, ValueError, SystemError):
 
 def _utc_now_iso() -> str:
     """Return current UTC time as ISO 8601 string with timezone info."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class ReviewSeverity(str, Enum):

--- a/apps/backend/runners/github/models.py
+++ b/apps/backend/runners/github/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
@@ -20,6 +20,11 @@ try:
     from .file_lock import locked_json_update, locked_json_write
 except (ImportError, ValueError, SystemError):
     from file_lock import locked_json_update, locked_json_write
+
+
+def _utc_now_iso() -> str:
+    """Return current UTC time as ISO 8601 string with timezone info."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 class ReviewSeverity(str, Enum):
@@ -521,7 +526,7 @@ class PRReviewResult:
     summary: str = ""
     overall_status: str = "comment"  # approve, request_changes, comment
     review_id: int | None = None
-    reviewed_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    reviewed_at: str = field(default_factory=lambda: _utc_now_iso())
     error: str | None = None
 
     # NEW: Enhanced verdict system
@@ -610,7 +615,7 @@ class PRReviewResult:
             summary=data.get("summary", ""),
             overall_status=data.get("overall_status", "comment"),
             review_id=data.get("review_id"),
-            reviewed_at=data.get("reviewed_at", datetime.now().isoformat()),
+            reviewed_at=data.get("reviewed_at", _utc_now_iso()),
             error=data.get("error"),
             # NEW fields
             verdict=MergeVerdict(data.get("verdict", "ready_to_merge")),
@@ -691,7 +696,7 @@ class PRReviewResult:
                 reviews.append(entry)
 
             current_data["reviews"] = reviews
-            current_data["last_updated"] = datetime.now().isoformat()
+            current_data["last_updated"] = _utc_now_iso()
 
             return current_data
 
@@ -762,7 +767,7 @@ class TriageResult:
     suggested_breakdown: list[str] = field(default_factory=list)
     priority: str = "medium"  # high, medium, low
     comment: str | None = None
-    triaged_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    triaged_at: str = field(default_factory=lambda: _utc_now_iso())
 
     def to_dict(self) -> dict:
         return {
@@ -798,7 +803,7 @@ class TriageResult:
             suggested_breakdown=data.get("suggested_breakdown", []),
             priority=data.get("priority", "medium"),
             comment=data.get("comment"),
-            triaged_at=data.get("triaged_at", datetime.now().isoformat()),
+            triaged_at=data.get("triaged_at", _utc_now_iso()),
         )
 
     async def save(self, github_dir: Path) -> None:
@@ -836,8 +841,8 @@ class AutoFixState:
     pr_url: str | None = None
     bot_comments: list[str] = field(default_factory=list)
     error: str | None = None
-    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
-    updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    created_at: str = field(default_factory=lambda: _utc_now_iso())
+    updated_at: str = field(default_factory=lambda: _utc_now_iso())
 
     def to_dict(self) -> dict:
         return {
@@ -875,8 +880,8 @@ class AutoFixState:
             pr_url=data.get("pr_url"),
             bot_comments=data.get("bot_comments", []),
             error=data.get("error"),
-            created_at=data.get("created_at", datetime.now().isoformat()),
-            updated_at=data.get("updated_at", datetime.now().isoformat()),
+            created_at=data.get("created_at", _utc_now_iso()),
+            updated_at=data.get("updated_at", _utc_now_iso()),
         )
 
     def update_status(self, status: AutoFixStatus) -> None:
@@ -886,7 +891,7 @@ class AutoFixState:
                 f"Invalid state transition: {self.status.value} -> {status.value}"
             )
         self.status = status
-        self.updated_at = datetime.now().isoformat()
+        self.updated_at = _utc_now_iso()
 
     async def save(self, github_dir: Path) -> None:
         """Save auto-fix state to .auto-claude/github/issues/ with file locking."""
@@ -938,7 +943,7 @@ class AutoFixState:
                 queue.append(entry)
 
             current_data["auto_fix_queue"] = queue
-            current_data["last_updated"] = datetime.now().isoformat()
+            current_data["last_updated"] = _utc_now_iso()
 
             return current_data
 

--- a/apps/backend/runners/github/services/followup_reviewer.py
+++ b/apps/backend/runners/github/services/followup_reviewer.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +32,7 @@ try:
         PRReviewResult,
         ReviewCategory,
         ReviewSeverity,
+        _utc_now_iso,
     )
     from .category_utils import map_category
     from .io_utils import safe_print
@@ -46,6 +46,7 @@ except (ImportError, ValueError, SystemError):
         PRReviewResult,
         ReviewCategory,
         ReviewSeverity,
+        _utc_now_iso,
     )
     from services.category_utils import map_category
     from services.io_utils import safe_print
@@ -265,7 +266,7 @@ class FollowupReviewer:
             verdict=verdict,
             verdict_reasoning=verdict_reasoning,
             blockers=blockers,
-            reviewed_at=datetime.now().isoformat(),
+            reviewed_at=_utc_now_iso(),
             # Follow-up specific fields
             reviewed_commit_sha=context.current_commit_sha,
             reviewed_file_blobs=file_blobs,


### PR DESCRIPTION
## Summary

Fix follow-up PR reviews missing human comments due to a timezone mismatch between stored `reviewed_at` timestamps and the GitHub API's `since` parameter.

## Problem

`datetime.now().isoformat()` produces **local time without timezone info** (e.g., `2026-02-12T12:10:00` in CET). When passed to GitHub API's `since` parameter, GitHub interprets it as **UTC**. In CET (UTC+1), this shifts the cutoff 1 hour into the future, causing the API to exclude comments that were posted after the review but within that timezone offset window.

**Concrete example from PR #1791:**
- Previous review completed at ~12:10 CET (= 11:10 UTC)
- `reviewed_at` stored as `2026-02-12T12:10:00` (local, no TZ)
- GitHub interprets `since=2026-02-12T12:10:00` as UTC 12:10:00Z
- Human comment posted at `11:44:34Z` was excluded (`11:44:34Z < 12:10:00Z`)
- With correct UTC timestamp, `11:44:34Z > 11:10:00Z` → included

## Solution

- Added `_utc_now_iso()` helper in `models.py` that returns `datetime.now(timezone.utc).isoformat()` 
- Replaced all `datetime.now().isoformat()` calls in `models.py` with the helper
- Updated `followup_reviewer.py` to import and use the shared helper
- UTC timestamps include `+00:00` suffix so GitHub correctly interprets them

## Changes

- `apps/backend/runners/github/models.py` — Added `_utc_now_iso()` helper, replaced 12 instances of naive `datetime.now().isoformat()`
- `apps/backend/runners/github/services/followup_reviewer.py` — Import and use `_utc_now_iso()` for `reviewed_at`

## Testing

- [x] All 2100+ backend tests pass
- [x] ruff check + format clean
- [x] Verified `datetime.now(timezone.utc).isoformat()` produces GitHub API-compatible format
- [x] `get_reviews_since()` already handles both naive and aware timestamps for backward compatibility with old stored values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified timestamp handling: all review, triage, and auto-fix records now use timezone-aware UTC timestamps. Defaults, missing-value fallbacks, and update timestamps are standardized to UTC, ensuring consistent, reliable displayed and stored times across the backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->