### PR TITLE
feat(roadmap): add expand/collapse functionality for phase features

### DIFF
--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -97,11 +97,18 @@ export function PhaseCard({
         <h4 className="text-sm font-medium mb-2">Features ({features.length})</h4>
         <div className="grid gap-2">
           {visibleFeatures.map((feature) => (
-            <button
-              type="button"
+            <div
               key={feature.id}
-              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors w-full text-left"
+              role="button"
+              tabIndex={0}
+              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
               onClick={() => onFeatureSelect(feature)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onFeatureSelect(feature);
+                }
+              }}
             >
               <div className="flex items-center gap-2 flex-1 min-w-0">
                 <Badge
@@ -148,7 +155,7 @@ export function PhaseCard({
                   Build
                 </Button>
               )}
-            </button>
+            </div>
           ))}
           {hasMoreFeatures && (
             <Button

--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -1,4 +1,6 @@
-import { CheckCircle2, Circle, ExternalLink, Play, TrendingUp } from 'lucide-react';
+import { useState } from 'react';
+import { CheckCircle2, ChevronDown, ChevronUp, Circle, ExternalLink, Play, TrendingUp } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { TaskOutcomeBadge } from './TaskOutcomeBadge';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -6,6 +8,8 @@ import { Card } from '../ui/card';
 import { Progress } from '../ui/progress';
 import { ROADMAP_PRIORITY_COLORS } from '../../../shared/constants';
 import type { PhaseCardProps } from './types';
+
+const INITIAL_VISIBLE_COUNT = 5;
 
 export function PhaseCard({
   phase,
@@ -15,8 +19,13 @@ export function PhaseCard({
   onConvertToSpec,
   onGoToTask,
 }: PhaseCardProps) {
+  const { t } = useTranslation('common');
+  const [isExpanded, setIsExpanded] = useState(false);
   const completedCount = features.filter((f) => f.status === 'done').length;
   const progress = features.length > 0 ? (completedCount / features.length) * 100 : 0;
+  const visibleFeatures = isExpanded ? features : features.slice(0, INITIAL_VISIBLE_COUNT);
+  const hiddenCount = features.length - INITIAL_VISIBLE_COUNT;
+  const hasMoreFeatures = hiddenCount > 0;
 
   return (
     <Card className="p-4">
@@ -87,7 +96,7 @@ export function PhaseCard({
       <div>
         <h4 className="text-sm font-medium mb-2">Features ({features.length})</h4>
         <div className="grid gap-2">
-          {features.slice(0, 5).map((feature) => (
+          {visibleFeatures.map((feature) => (
             <div
               key={feature.id}
               className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
@@ -140,10 +149,24 @@ export function PhaseCard({
               )}
             </div>
           ))}
-          {features.length > 5 && (
-            <div className="text-sm text-muted-foreground text-center py-1">
-              +{features.length - 5} more features
-            </div>
+          {hasMoreFeatures && (
+            <button
+              type="button"
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground text-center py-1 transition-colors cursor-pointer"
+            >
+              {isExpanded ? (
+                <>
+                  <ChevronUp className="h-4 w-4" />
+                  {t('roadmap.showLessFeatures')}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" />
+                  {t('roadmap.showMoreFeatures', { count: hiddenCount })}
+                </>
+              )}
+            </button>
           )}
         </div>
       </div>

--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -103,7 +103,7 @@ export function PhaseCard({
             >
               <button
                 type="button"
-                className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+                className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 onClick={() => onFeatureSelect(feature)}
               >
                 <Badge

--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -97,9 +97,10 @@ export function PhaseCard({
         <h4 className="text-sm font-medium mb-2">Features ({features.length})</h4>
         <div className="grid gap-2">
           {visibleFeatures.map((feature) => (
-            <div
+            <button
+              type="button"
               key={feature.id}
-              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
+              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors w-full text-left"
               onClick={() => onFeatureSelect(feature)}
             >
               <div className="flex items-center gap-2 flex-1 min-w-0">
@@ -147,13 +148,13 @@ export function PhaseCard({
                   Build
                 </Button>
               )}
-            </div>
+            </button>
           ))}
           {hasMoreFeatures && (
             <Button
               type="button"
               variant="ghost"
-              onClick={() => setIsExpanded(!isExpanded)}
+              onClick={() => setIsExpanded((prev) => !prev)}
               aria-expanded={isExpanded}
               className="flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground w-full"
             >

--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -99,18 +99,13 @@ export function PhaseCard({
           {visibleFeatures.map((feature) => (
             <div
               key={feature.id}
-              role="button"
-              tabIndex={0}
-              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
-              onClick={() => onFeatureSelect(feature)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onFeatureSelect(feature);
-                }
-              }}
+              className="flex items-center justify-between p-2 rounded-md bg-muted/50 hover:bg-muted transition-colors"
             >
-              <div className="flex items-center gap-2 flex-1 min-w-0">
+              <button
+                type="button"
+                className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+                onClick={() => onFeatureSelect(feature)}
+              >
                 <Badge
                   variant="outline"
                   className={`text-xs ${ROADMAP_PRIORITY_COLORS[feature.priority]}`}
@@ -121,7 +116,7 @@ export function PhaseCard({
                 {feature.competitorInsightIds && feature.competitorInsightIds.length > 0 && (
                   <TrendingUp className="h-3 w-3 text-primary flex-shrink-0" />
                 )}
-              </div>
+              </button>
               {feature.taskOutcome ? (
                 <span className="flex-shrink-0">
                   <TaskOutcomeBadge outcome={feature.taskOutcome} size="lg" showLabel={false} />

--- a/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/PhaseCard.tsx
@@ -150,10 +150,12 @@ export function PhaseCard({
             </div>
           ))}
           {hasMoreFeatures && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => setIsExpanded(!isExpanded)}
-              className="flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground text-center py-1 transition-colors cursor-pointer"
+              aria-expanded={isExpanded}
+              className="flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground w-full"
             >
               {isExpanded ? (
                 <>
@@ -166,7 +168,7 @@ export function PhaseCard({
                   {t('roadmap.showMoreFeatures', { count: hiddenCount })}
                 </>
               )}
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/apps/frontend/src/shared/i18n/locales/en/common.json
+++ b/apps/frontend/src/shared/i18n/locales/en/common.json
@@ -598,7 +598,8 @@
     "taskCompleted": "Completed",
     "taskDeleted": "Deleted",
     "taskArchived": "Archived",
-    "showMoreFeatures": "Show {{count}} more features",
+    "showMoreFeatures": "Show {{count}} more feature",
+    "showMoreFeatures_plural": "Show {{count}} more features",
     "showLessFeatures": "Show less"
   },
   "roadmapGeneration": {

--- a/apps/frontend/src/shared/i18n/locales/en/common.json
+++ b/apps/frontend/src/shared/i18n/locales/en/common.json
@@ -597,7 +597,9 @@
   "roadmap": {
     "taskCompleted": "Completed",
     "taskDeleted": "Deleted",
-    "taskArchived": "Archived"
+    "taskArchived": "Archived",
+    "showMoreFeatures": "Show {{count}} more features",
+    "showLessFeatures": "Show less"
   },
   "roadmapGeneration": {
     "progress": "Progress",

--- a/apps/frontend/src/shared/i18n/locales/fr/common.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/common.json
@@ -598,7 +598,8 @@
     "taskCompleted": "Terminé",
     "taskDeleted": "Supprimé",
     "taskArchived": "Archivé",
-    "showMoreFeatures": "Afficher {{count}} fonctionnalités supplémentaires",
+    "showMoreFeatures": "Afficher {{count}} fonctionnalité supplémentaire",
+    "showMoreFeatures_plural": "Afficher {{count}} fonctionnalités supplémentaires",
     "showLessFeatures": "Afficher moins"
   },
   "roadmapGeneration": {

--- a/apps/frontend/src/shared/i18n/locales/fr/common.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/common.json
@@ -597,7 +597,9 @@
   "roadmap": {
     "taskCompleted": "Terminé",
     "taskDeleted": "Supprimé",
-    "taskArchived": "Archivé"
+    "taskArchived": "Archivé",
+    "showMoreFeatures": "Afficher {{count}} fonctionnalités supplémentaires",
+    "showLessFeatures": "Afficher moins"
   },
   "roadmapGeneration": {
     "progress": "Progression",


### PR DESCRIPTION
## Summary
- Adds expand/collapse functionality to the Roadmap Phases view
- Each phase can now show all its features instead of just the first 5
- Clickable toggle button with visual feedback (chevron icons)
- Includes i18n translations for English and French

## Changes
- **PhaseCard.tsx**: Added `useState` hook for expanded state, conditional rendering based on state, and a toggle button with `ChevronDown`/`ChevronUp` icons
- **en/common.json**: Added `roadmap.showMoreFeatures` and `roadmap.showLessFeatures` keys
- **fr/common.json**: Added French translations for the new keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase cards now support expandable/collapsible feature lists with a toggle button, chevron indicators, keyboard accessibility, and full-width clickable feature rows for easier interaction.

* **Documentation**
  * Added English and French translations for "Show more features" (with plural forms) and "Show less" labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->