### PR TITLE
fix(sentry): enable Sentry for Python subprocesses and add diagnostic instrumentation

### DIFF
--- a/apps/backend/core/sentry.py
+++ b/apps/backend/core/sentry.py
@@ -212,23 +212,11 @@ def init_sentry(
         logger.debug("[Sentry] No SENTRY_DSN configured - error reporting disabled")
         return False
 
-    # Check if we should enable Sentry
-    # Enable if:
-    # - Running from packaged app (detected by __compiled__ or frozen)
-    # - SENTRY_DEV=true is set
-    # - force_enable is True
+    # DSN is present (checked above), so Sentry should be enabled.
+    # The Electron main process only passes SENTRY_DSN to subprocesses in
+    # production builds, so its presence is sufficient to gate activation.
+    # In dev, you can still opt-in via SENTRY_DEV=true + SENTRY_DSN.
     is_packaged = getattr(sys, "frozen", False) or hasattr(sys, "__compiled__")
-    sentry_dev = os.environ.get("SENTRY_DEV", "").lower() in ("true", "1", "yes")
-    # Also treat explicitly-set DSN as "packaged" — the Electron main process
-    # only passes SENTRY_DSN to subprocesses in production builds
-    dsn_explicitly_set = bool(dsn)
-    should_enable = is_packaged or sentry_dev or dsn_explicitly_set or force_enable
-
-    if not should_enable:
-        logger.debug(
-            "[Sentry] Development mode - error reporting disabled (set SENTRY_DEV=true to enable)"
-        )
-        return False
 
     try:
         import sentry_sdk

--- a/apps/backend/core/sentry.py
+++ b/apps/backend/core/sentry.py
@@ -219,7 +219,10 @@ def init_sentry(
     # - force_enable is True
     is_packaged = getattr(sys, "frozen", False) or hasattr(sys, "__compiled__")
     sentry_dev = os.environ.get("SENTRY_DEV", "").lower() in ("true", "1", "yes")
-    should_enable = is_packaged or sentry_dev or force_enable
+    # Also treat explicitly-set DSN as "packaged" — the Electron main process
+    # only passes SENTRY_DSN to subprocesses in production builds
+    dsn_explicitly_set = bool(dsn)
+    should_enable = is_packaged or sentry_dev or dsn_explicitly_set or force_enable
 
     if not should_enable:
         logger.debug(

--- a/apps/backend/core/sentry.py
+++ b/apps/backend/core/sentry.py
@@ -186,14 +186,12 @@ def _before_send(event: dict, hint: dict) -> dict | None:
 
 def init_sentry(
     component: str = "backend",
-    force_enable: bool = False,
 ) -> bool:
     """
     Initialize Sentry for the Python backend.
 
     Args:
         component: Component name for tagging (e.g., "backend", "github-runner")
-        force_enable: Force enable even without packaged app detection
 
     Returns:
         True if Sentry was initialized, False otherwise
@@ -215,7 +213,7 @@ def init_sentry(
     # DSN is present (checked above), so Sentry should be enabled.
     # The Electron main process only passes SENTRY_DSN to subprocesses in
     # production builds, so its presence is sufficient to gate activation.
-    # In dev, you can still opt-in via SENTRY_DEV=true + SENTRY_DSN.
+    # In dev, set SENTRY_DSN in your environment to opt-in.
     is_packaged = getattr(sys, "frozen", False) or hasattr(sys, "__compiled__")
 
     try:

--- a/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
@@ -37,6 +37,7 @@ import {
 } from "./utils/subprocess-runner";
 import { getPRStatusPoller } from "../../services/pr-status-poller";
 import { safeBreadcrumb, safeCaptureException } from "../../sentry";
+import { sanitizeForSentry } from "../../../shared/utils/sentry-privacy";
 import type {
   StartPollingRequest,
   StopPollingRequest,
@@ -1553,7 +1554,7 @@ async function runPRReview(
 
       safeCaptureException(
         new Error(`PR review subprocess failed: ${result.error ?? 'unknown error'}`),
-        { extra: { exitCode: result.exitCode, prNumber, stderr: result.stderr.slice(0, 500) } }
+        { extra: { exitCode: result.exitCode, prNumber, stderr: sanitizeForSentry(result.stderr.slice(0, 500)) } }
       );
 
       throw new Error(result.error ?? "Review failed");
@@ -2935,6 +2936,20 @@ export function registerPRHandlers(getMainWindow: () => BrowserWindow | null): v
 
           debugLog("Spawning follow-up review process", { args, model, thinkingLevel });
 
+          safeBreadcrumb({
+            category: 'pr-review',
+            message: 'Spawning follow-up PR review subprocess',
+            level: 'info',
+            data: {
+              pythonPath: getPythonPath(backendPath),
+              runnerPath: getRunnerPath(backendPath),
+              cwd: backendPath,
+              model,
+              thinkingLevel,
+              prNumber,
+            },
+          });
+
           // Create log collector for this follow-up review (config already declared above)
           const repo = config?.repo || project.name || "unknown";
           const logCollector = new PRLogCollector(project, prNumber, repo, true, mainWindow);
@@ -2992,9 +3007,22 @@ export function registerPRHandlers(getMainWindow: () => BrowserWindow | null): v
 
             const result = await promise;
 
+            safeBreadcrumb({
+              category: 'pr-review',
+              message: 'Follow-up PR review subprocess exited',
+              level: result.success ? 'info' : 'error',
+              data: { exitCode: result.exitCode, success: result.success, prNumber },
+            });
+
             if (!result.success) {
               // Finalize logs with failure
               logCollector.finalize(false);
+
+              safeCaptureException(
+                new Error(`Follow-up PR review subprocess failed: ${result.error ?? 'unknown error'}`),
+                { extra: { exitCode: result.exitCode, prNumber, stderr: sanitizeForSentry(result.stderr.slice(0, 500)) } }
+              );
+
               throw new Error(result.error ?? "Follow-up review failed");
             }
 

--- a/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
@@ -36,6 +36,7 @@ import {
   buildRunnerArgs,
 } from "./utils/subprocess-runner";
 import { getPRStatusPoller } from "../../services/pr-status-poller";
+import { safeBreadcrumb, safeCaptureException } from "../../sentry";
 import type {
   StartPollingRequest,
   StopPollingRequest,
@@ -1462,6 +1463,19 @@ async function runPRReview(
 
   debugLog("Spawning PR review process", { args, model, thinkingLevel });
 
+  safeBreadcrumb({
+    category: 'pr-review',
+    message: 'Spawning PR review subprocess',
+    data: {
+      pythonPath: getPythonPath(backendPath),
+      runnerPath: getRunnerPath(backendPath),
+      cwd: backendPath,
+      model,
+      thinkingLevel,
+      prNumber,
+    },
+  });
+
   // Create log collector for this review
   const config = getGitHubConfig(project);
   const repo = config?.repo || project.name || "unknown";
@@ -1525,9 +1539,21 @@ async function runPRReview(
     // Wait for the process to complete
     const result = await promise;
 
+    safeBreadcrumb({
+      category: 'pr-review',
+      message: `PR review subprocess exited`,
+      data: { exitCode: result.exitCode, success: result.success, prNumber },
+    });
+
     if (!result.success) {
       // Finalize logs with failure
       logCollector.finalize(false);
+
+      safeCaptureException(
+        new Error(`PR review subprocess failed: ${result.error ?? 'unknown error'}`),
+        { extra: { exitCode: result.exitCode, prNumber, stderr: result.stderr.slice(0, 500) } }
+      );
+
       throw new Error(result.error ?? "Review failed");
     }
 

--- a/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/pr-handlers.ts
@@ -1466,6 +1466,7 @@ async function runPRReview(
   safeBreadcrumb({
     category: 'pr-review',
     message: 'Spawning PR review subprocess',
+    level: 'info',
     data: {
       pythonPath: getPythonPath(backendPath),
       runnerPath: getRunnerPath(backendPath),
@@ -1542,6 +1543,7 @@ async function runPRReview(
     safeBreadcrumb({
       category: 'pr-review',
       message: `PR review subprocess exited`,
+      level: result.success ? 'info' : 'error',
       data: { exitCode: result.exitCode, success: result.success, prNumber },
     });
 

--- a/apps/frontend/src/main/ipc-handlers/github/utils/runner-env.ts
+++ b/apps/frontend/src/main/ipc-handlers/github/utils/runner-env.ts
@@ -3,6 +3,7 @@ import { getAPIProfileEnv } from '../../../services/profile';
 import { getBestAvailableProfileEnv } from '../../../rate-limit-detector';
 import { pythonEnvManager } from '../../../python-env-manager';
 import { getGitHubTokenForSubprocess } from '../utils';
+import { getSentryEnvForSubprocess } from '../../../sentry';
 
 /**
  * Get environment variables for Python runner subprocesses.
@@ -48,6 +49,7 @@ export async function getRunnerEnv(
     ...oauthModeClearVars,
     ...profileEnv,  // OAuth token from profile manager (fixes #563, rate-limit aware)
     ...githubEnv,  // Fresh GitHub token from gh CLI (fixes #151)
-    ...extraEnv,
+    ...getSentryEnvForSubprocess(),  // Sentry DSN + sample rates for Python subprocess
+    ...extraEnv,  // extraEnv last so callers can still override
   };
 }

--- a/apps/frontend/src/main/python-env-manager.ts
+++ b/apps/frontend/src/main/python-env-manager.ts
@@ -753,6 +753,8 @@ if sys.version_info >= (3, 12):
       ...windowsEnv,
       // Don't write bytecode - not needed and avoids permission issues
       PYTHONDONTWRITEBYTECODE: '1',
+      // Force unbuffered stdout/stderr so progress updates reach Electron immediately
+      PYTHONUNBUFFERED: '1',
       // Use UTF-8 encoding
       PYTHONIOENCODING: 'utf-8',
       PYTHONUTF8: '1',

--- a/apps/frontend/src/main/sentry.ts
+++ b/apps/frontend/src/main/sentry.ts
@@ -222,7 +222,5 @@ export function getSentryEnvForSubprocess(): Record<string, string> {
     SENTRY_DSN: dsn,
     SENTRY_TRACES_SAMPLE_RATE: String(getTracesSampleRate()),
     SENTRY_PROFILES_SAMPLE_RATE: String(getProfilesSampleRate()),
-    // Pass SENTRY_DEV so Python backend also enables Sentry in dev mode
-    ...(process.env.SENTRY_DEV ? { SENTRY_DEV: process.env.SENTRY_DEV } : {}),
   };
 }


### PR DESCRIPTION
## Summary

- **Pass Sentry env vars to GitHub runner subprocesses** — `getRunnerEnv()` now includes `getSentryEnvForSubprocess()`, matching the pattern already used in `env-utils.ts`
- **Fix Python Sentry packaged-mode detection** — `init_sentry()` now enables Sentry when `SENTRY_DSN` is explicitly set (via env var from Electron), since the Python subprocess isn't frozen/compiled
- **Add Sentry breadcrumbs to PR review lifecycle** — spawn event, exit event, and failure capture in `runPRReview`
- **Add 120s health-check timeout** — reports to Sentry if no stdout/stderr is received from a subprocess, helping diagnose production hangs
- **Force unbuffered Python output** — `PYTHONUNBUFFERED=1` in `getPythonEnv()` ensures progress updates reach Electron immediately

## Test plan

- [x] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend tests pass (`npm test -- --run` — 3208 passed)
- [x] Production build succeeds (`npm run package:mac`)
- [ ] In dev mode with `SENTRY_DEV=true`, trigger a PR review and verify Sentry events appear
- [ ] In production build, trigger PR review and check Sentry dashboard for breadcrumbs/events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer observability: more structured breadcrumbs, automatic error captures, and privacy-aware sanitization for error data.
  * Subprocess health checks that report stalled background processes.

* **Bug Fixes**
  * More reliable real-time output delivery from Python subprocesses.

* **Chores**
  * Forwarded monitoring environment to subprocesses and simplified Sentry activation to depend on DSN presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->