### PR TITLE
auto-claude: 218-enable-claude-code-features-in-worktree-terminals

### DIFF
--- a/apps/backend/core/workspace/setup.py
+++ b/apps/backend/core/workspace/setup.py
@@ -451,6 +451,13 @@ def setup_workspace(
     if symlinked_modules:
         print_status(f"Dependencies linked: {', '.join(symlinked_modules)}", "success")
 
+    # Symlink .claude/ config to worktree for Claude Code features (settings, commands, etc.)
+    symlinked_claude = symlink_claude_config_to_worktree(
+        project_dir, worktree_info.path
+    )
+    if symlinked_claude:
+        print_status(f"Claude config linked: {', '.join(symlinked_claude)}", "success")
+
     # Copy security configuration files if they exist
     # Note: Unlike env files, security files always overwrite to ensure
     # the worktree uses the same security rules as the main project.

--- a/apps/backend/core/workspace/setup.py
+++ b/apps/backend/core/workspace/setup.py
@@ -283,6 +283,75 @@ def symlink_node_modules_to_worktree(
     return symlinked
 
 
+def symlink_claude_config_to_worktree(
+    project_dir: Path, worktree_path: Path
+) -> list[str]:
+    """
+    Symlink .claude/ directory from project root to worktree.
+
+    This ensures the worktree has access to Claude Code configuration
+    (settings, CLAUDE.md, MCP servers, etc.) so that terminals opened
+    in the worktree behave identically to the project root.
+
+    Args:
+        project_dir: The main project directory
+        worktree_path: Path to the worktree
+
+    Returns:
+        List of symlinked paths (relative to worktree)
+    """
+    symlinked = []
+
+    source_path = project_dir / ".claude"
+    target_path = worktree_path / ".claude"
+
+    # Skip if source doesn't exist
+    if not source_path.exists():
+        debug(MODULE, "Skipping .claude/ - source does not exist")
+        return symlinked
+
+    # Skip if target already exists
+    if target_path.exists():
+        debug(MODULE, "Skipping .claude/ - target already exists")
+        return symlinked
+
+    # Also skip if target is a symlink (even if broken)
+    if target_path.is_symlink():
+        debug(MODULE, "Skipping .claude/ - symlink already exists (possibly broken)")
+        return symlinked
+
+    # Ensure parent directory exists
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if sys.platform == "win32":
+            # On Windows, use junctions instead of symlinks (no admin rights required)
+            result = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(target_path), str(source_path)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise OSError(result.stderr or "mklink /J failed")
+        else:
+            # On macOS/Linux, use relative symlinks for portability
+            relative_source = os.path.relpath(source_path, target_path.parent)
+            os.symlink(relative_source, target_path)
+        symlinked.append(".claude")
+        debug(MODULE, f"Symlinked .claude/ -> {source_path}")
+    except OSError as e:
+        debug_warning(
+            MODULE,
+            f"Could not symlink .claude/: {e}. Claude Code features may not work in worktree terminals.",
+        )
+        print_status(
+            "Warning: Could not link .claude/ - Claude Code features may not work in terminals",
+            "warning",
+        )
+
+    return symlinked
+
+
 def copy_spec_to_worktree(
     source_spec_dir: Path,
     worktree_path: Path,

--- a/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
@@ -312,6 +312,62 @@ function symlinkNodeModulesToWorktree(projectPath: string, worktreePath: string)
   return symlinked;
 }
 
+/**
+ * Symlink the project root's .claude/ directory into a terminal worktree.
+ * This enables Claude Code features (settings, commands, memory) in worktree terminals.
+ * Follows the same pattern as symlinkNodeModulesToWorktree().
+ */
+function symlinkClaudeConfigToWorktree(projectPath: string, worktreePath: string): string[] {
+  const symlinked: string[] = [];
+
+  const sourceRel = '.claude';
+  const sourcePath = path.join(projectPath, sourceRel);
+  const targetPath = path.join(worktreePath, sourceRel);
+
+  // Skip if source doesn't exist
+  if (!existsSync(sourcePath)) {
+    debugLog('[TerminalWorktree] Skipping .claude symlink - source does not exist:', sourcePath);
+    return symlinked;
+  }
+
+  // Skip if target already exists
+  if (existsSync(targetPath)) {
+    debugLog('[TerminalWorktree] Skipping .claude symlink - target already exists:', targetPath);
+    return symlinked;
+  }
+
+  // Also skip if target is a symlink (even if broken)
+  try {
+    lstatSync(targetPath);
+    debugLog('[TerminalWorktree] Skipping .claude symlink - target exists (possibly broken symlink):', targetPath);
+    return symlinked;
+  } catch {
+    // Target doesn't exist at all - good, we can create symlink
+  }
+
+  // Ensure parent directory exists
+  const targetDir = path.dirname(targetPath);
+  if (!existsSync(targetDir)) {
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  try {
+    if (isWindows()) {
+      symlinkSync(sourcePath, targetPath, 'junction');
+      debugLog('[TerminalWorktree] Created .claude junction (Windows):', sourceRel, '->', sourcePath);
+    } else {
+      const relativePath = path.relative(path.dirname(targetPath), sourcePath);
+      symlinkSync(relativePath, targetPath);
+      debugLog('[TerminalWorktree] Created .claude symlink (Unix):', sourceRel, '->', relativePath);
+    }
+    symlinked.push(sourceRel);
+  } catch (error) {
+    debugError('[TerminalWorktree] Could not create symlink for .claude:', error);
+  }
+
+  return symlinked;
+}
+
 function saveWorktreeConfig(projectPath: string, name: string, config: TerminalWorktreeConfig): void {
   const metadataDir = getTerminalWorktreeMetadataDir(projectPath);
   mkdirSync(metadataDir, { recursive: true });

--- a/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts
@@ -579,6 +579,12 @@ async function createTerminalWorktree(
       debugLog('[TerminalWorktree] Symlinked dependencies:', symlinkedModules.join(', '));
     }
 
+    // Symlink .claude/ config for Claude Code features (settings, commands, memory)
+    const symlinkedClaude = symlinkClaudeConfigToWorktree(projectPath, worktreePath);
+    if (symlinkedClaude.length > 0) {
+      debugLog('[TerminalWorktree] Symlinked Claude config:', symlinkedClaude.join(', '));
+    }
+
     const config: TerminalWorktreeConfig = {
       name,
       worktreePath,


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Enables Claude Code features (commands, skills, agents, settings) in terminal and task worktrees by symlinking the `.claude/` directory during worktree creation. This ensures worktree terminals have full feature parity with the main project root, following the same pattern already established for `node_modules` symlinking.

## Related Issue

Closes #218

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [ ] Backend
- [x] Fullstack

## Commit Message Format

Follow conventional commits: `<type>: <subject>`

**Types:** feat, fix, docs, style, refactor, test, chore

**Example:** `feat: add user authentication system`

## AI Disclosure

- [x] This PR includes AI-generated code (Claude, Codex, Copilot, etc.)

**Tool(s) used:** Claude Code

**Testing level:**
- [ ] Untested -- AI output not yet verified
- [x] Lightly tested -- ran the app / spot-checked key paths
- [ ] Fully tested -- all tests pass, manually verified behavior

- [x] I understand what this PR does and how the underlying code works

## Checklist

- [ ] I've synced with `develop` branch
- [ ] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

**CRITICAL:** This project supports Windows, macOS, and Linux. Platform-specific bugs are a common source of breakage.

- [ ] **Windows tested** (either on Windows or via CI)
- [ ] **macOS tested** (either on macOS or via CI)
- [ ] **Linux tested** (CI covers this)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [ ] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [ ] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

## Screenshots

Not applicable for backend/infrastructure changes.

## Feature Toggle

- [ ] Behind localStorage flag: `use_feature_name`
- [ ] Behind settings toggle
- [ ] Behind environment variable/config
- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

**Details:**
This change is additive and backward compatible. Existing worktree creation logic remains unchanged; the `.claude/` symlink is created alongside existing `node_modules` symlinking with graceful degradation if the source directory doesn't exist.

## Change Summary

### What Changed
- **Backend (`apps/backend/core/workspace/setup.py`):** Added `symlink_claude_config_to_worktree()` function that creates a symlink from the project's `.claude/` directory to the worktree during `setup_workspace()`. Handles Windows (junctions) and Unix (relative symlinks) with appropriate error handling.
- **Frontend (`apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts`):** Added `symlinkClaudeConfigToWorktree()` function that creates a symlink during terminal worktree creation in `createTerminalWorktree()`. Follows the exact same pattern as the existing `symlinkNodeModulesToWorktree()` function.

### Why These Changes
Worktrees created by the application were missing access to Claude Code features because the `.claude/` directory (containing commands, skills, agents, and settings) is in `.gitignore` and thus absent from git worktrees. By symlinking this directory, worktree terminals gain full Claude Code feature parity with the main project.

### How It Works
Both functions follow an identical pattern:
1. Check if source `.claude/` directory exists in the main project (skip silently if not)
2. Check if target already exists in worktree (skip if present or if symlink exists)
3. Create parent directories if needed
4. On Windows: Use `mklink /J` to create directory junction (no admin rights required)
5. On macOS/Linux: Create relative symlink for portability
6. Log operations and non-fatal errors; never fail worktree creation

### Files Modified
- `apps/backend/core/workspace/setup.py` (+76 lines)
- `apps/frontend/src/main/ipc-handlers/terminal/worktree-handlers.ts` (+62 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Claude configuration is now automatically linked to worktree environments, enabling Claude Code features to function properly in isolated terminal worktrees. The system provides feedback when linking succeeds or if issues occur during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->