### PR TITLE
fix: prevent OOM, orphaned agents, and unbounded growth during overnight builds

### DIFF
--- a/apps/backend/core/progress.py
+++ b/apps/backend/core/progress.py
@@ -9,7 +9,10 @@ Enhanced with colored output, icons, and better visual formatting.
 """
 
 import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from core.plan_normalization import normalize_subtask_aliases
 from ui import (
@@ -230,8 +233,8 @@ def print_progress_summary(spec_dir: Path, show_next: bool = True) -> None:
                         f"  {icon(Icons.ARROW_RIGHT)} Next: {highlight(next_id)} - {next_desc}"
                     )
 
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-            pass  # Ignore corrupted/unreadable progress files
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+            logger.debug("Failed to load plan file for phase summary: %s", e)
     else:
         print()
         print_status("No implementation subtasks yet - planner needs to run", "pending")
@@ -404,6 +407,8 @@ def get_next_subtask(spec_dir: Path) -> dict | None:
     """
     Find the next subtask to work on, respecting phase dependencies.
 
+    Skips subtasks that are marked as stuck in the recovery manager's attempt history.
+
     Args:
         spec_dir: Directory containing implementation_plan.json
 
@@ -414,6 +419,23 @@ def get_next_subtask(spec_dir: Path) -> dict | None:
 
     if not plan_file.exists():
         return None
+
+    # Load stuck subtasks from recovery manager's attempt history
+    stuck_subtask_ids = set()
+    attempt_history_file = spec_dir / "memory" / "attempt_history.json"
+    if attempt_history_file.exists():
+        try:
+            with open(attempt_history_file, encoding="utf-8") as f:
+                attempt_history = json.load(f)
+            # Collect IDs of subtasks marked as stuck
+            stuck_subtask_ids = {
+                entry["subtask_id"]
+                for entry in attempt_history.get("stuck_subtasks", [])
+                if "subtask_id" in entry
+            }
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            # If we can't read the file, continue without stuck checking
+            pass
 
     try:
         with open(plan_file, encoding="utf-8") as f:
@@ -455,9 +477,15 @@ def get_next_subtask(spec_dir: Path) -> dict | None:
             if not deps_satisfied:
                 continue
 
-            # Find first pending subtask in this phase
+            # Find first pending subtask in this phase (skip stuck subtasks)
             for subtask in phase.get("subtasks", phase.get("chunks", [])):
                 status = subtask.get("status", "pending")
+                subtask_id = subtask.get("id")
+
+                # Skip stuck subtasks
+                if subtask_id in stuck_subtask_ids:
+                    continue
+
                 if status in {"pending", "not_started", "not started"}:
                     subtask_out, _changed = normalize_subtask_aliases(subtask)
                     subtask_out["status"] = "pending"

--- a/apps/backend/core/progress.py
+++ b/apps/backend/core/progress.py
@@ -234,7 +234,7 @@ def print_progress_summary(spec_dir: Path, show_next: bool = True) -> None:
                     )
 
         except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
-            logger.debug("Failed to load plan file for phase summary: %s", e)
+            logger.debug(f"Failed to load plan file for phase summary: {e}")
     else:
         print()
         print_status("No implementation subtasks yet - planner needs to run", "pending")

--- a/apps/backend/integrations/graphiti/queries_pkg/client.py
+++ b/apps/backend/integrations/graphiti/queries_pkg/client.py
@@ -226,24 +226,19 @@ class GraphitiClient:
                         self._driver = create_patched_kuzu_driver(db=str(db_path))
                         if attempt > 0:
                             logger.info(
-                                "LadybugDB lock acquired after %d retries", attempt
+                                f"LadybugDB lock acquired after {attempt} retries"
                             )
                         break  # Success
                     except Exception as e:
                         if _is_lock_error(e) and attempt < MAX_LOCK_RETRIES:
                             wait_time = _backoff_with_jitter(attempt)
                             logger.debug(
-                                "LadybugDB lock contention (attempt %d/%d), retrying in %.2fs",
-                                attempt + 1,
-                                MAX_LOCK_RETRIES,
-                                wait_time,
+                                f"LadybugDB lock contention (attempt {attempt + 1}/{MAX_LOCK_RETRIES}), retrying in {wait_time:.2f}s"
                             )
                             await asyncio.sleep(wait_time)
                             continue
                         logger.warning(
-                            "Failed to initialize LadybugDB driver at %s: %s",
-                            db_path,
-                            e,
+                            f"Failed to initialize LadybugDB driver at {db_path}: {e}"
                         )
                         capture_exception(
                             e,

--- a/apps/backend/integrations/graphiti/queries_pkg/client.py
+++ b/apps/backend/integrations/graphiti/queries_pkg/client.py
@@ -5,7 +5,9 @@ Handles database connection, initialization, and lifecycle management.
 Uses LadybugDB as the embedded graph database (no Docker required, Python 3.12+).
 """
 
+import asyncio
 import logging
+import random
 import sys
 from datetime import datetime, timezone
 
@@ -13,6 +15,27 @@ from core.sentry import capture_exception
 from graphiti_config import GraphitiConfig, GraphitiState
 
 logger = logging.getLogger(__name__)
+
+# Retry configuration for LadybugDB lock contention
+MAX_LOCK_RETRIES = 5
+INITIAL_BACKOFF_SECONDS = 0.5
+MAX_BACKOFF_SECONDS = 8.0
+JITTER_PERCENT = 0.2
+
+
+def _is_lock_error(error: Exception) -> bool:
+    """Check if an error indicates database lock contention."""
+    error_msg = str(error).lower()
+    return "could not set lock" in error_msg or (
+        "lock" in error_msg and ("file" in error_msg or "database" in error_msg)
+    )
+
+
+def _backoff_with_jitter(attempt: int) -> float:
+    """Calculate exponential backoff with jitter for retry delays."""
+    backoff = min(INITIAL_BACKOFF_SECONDS * (2**attempt), MAX_BACKOFF_SECONDS)
+    jitter = backoff * JITTER_PERCENT * (2 * random.random() - 1)
+    return max(0.01, backoff + jitter)
 
 
 def _apply_ladybug_monkeypatch() -> bool:
@@ -196,32 +219,41 @@ class GraphitiClient:
                 )
 
                 db_path = self.config.get_db_path()
-                try:
-                    self._driver = create_patched_kuzu_driver(db=str(db_path))
-                except (OSError, PermissionError) as e:
-                    logger.warning(
-                        f"Failed to initialize LadybugDB driver at {db_path}: {e}"
-                    )
-                    capture_exception(
-                        e,
-                        error_type=type(e).__name__,
-                        db_path=str(db_path),
-                        llm_provider=self.config.llm_provider,
-                        embedder_provider=self.config.embedder_provider,
-                    )
-                    return False
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error initializing LadybugDB driver at {db_path}: {e}"
-                    )
-                    capture_exception(
-                        e,
-                        error_type=type(e).__name__,
-                        db_path=str(db_path),
-                        llm_provider=self.config.llm_provider,
-                        embedder_provider=self.config.embedder_provider,
-                    )
-                    return False
+
+                # Retry with exponential backoff for lock contention
+                for attempt in range(MAX_LOCK_RETRIES + 1):
+                    try:
+                        self._driver = create_patched_kuzu_driver(db=str(db_path))
+                        if attempt > 0:
+                            logger.info(
+                                "LadybugDB lock acquired after %d retries", attempt
+                            )
+                        break  # Success
+                    except Exception as e:
+                        if _is_lock_error(e) and attempt < MAX_LOCK_RETRIES:
+                            wait_time = _backoff_with_jitter(attempt)
+                            logger.debug(
+                                "LadybugDB lock contention (attempt %d/%d), retrying in %.2fs",
+                                attempt + 1,
+                                MAX_LOCK_RETRIES,
+                                wait_time,
+                            )
+                            await asyncio.sleep(wait_time)
+                            continue
+                        logger.warning(
+                            "Failed to initialize LadybugDB driver at %s: %s",
+                            db_path,
+                            e,
+                        )
+                        capture_exception(
+                            e,
+                            error_type=type(e).__name__,
+                            db_path=str(db_path),
+                            llm_provider=self.config.llm_provider,
+                            embedder_provider=self.config.embedder_provider,
+                        )
+                        return False
+
                 logger.info(f"Initialized LadybugDB driver (patched) at: {db_path}")
             except ImportError as e:
                 logger.warning(f"KuzuDriver not available: {e}")

--- a/apps/backend/services/recovery.py
+++ b/apps/backend/services/recovery.py
@@ -14,11 +14,18 @@ Key Features:
 """
 
 import json
+import logging
 import subprocess
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
+
+# Recovery manager configuration
+ATTEMPT_WINDOW_SECONDS = 7200  # Only count attempts within last 2 hours
+MAX_ATTEMPT_HISTORY_PER_SUBTASK = 50  # Cap stored attempts per subtask
+
+logger = logging.getLogger(__name__)
 
 
 class FailureType(Enum):
@@ -82,8 +89,8 @@ class RecoveryManager:
             "subtasks": {},
             "stuck_subtasks": [],
             "metadata": {
-                "created_at": datetime.now().isoformat(),
-                "last_updated": datetime.now().isoformat(),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_updated": datetime.now(timezone.utc).isoformat(),
             },
         }
         with open(self.attempt_history_file, "w", encoding="utf-8") as f:
@@ -95,8 +102,8 @@ class RecoveryManager:
             "commits": [],
             "last_good_commit": None,
             "metadata": {
-                "created_at": datetime.now().isoformat(),
-                "last_updated": datetime.now().isoformat(),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "last_updated": datetime.now(timezone.utc).isoformat(),
             },
         }
         with open(self.build_commits_file, "w", encoding="utf-8") as f:
@@ -114,7 +121,7 @@ class RecoveryManager:
 
     def _save_attempt_history(self, data: dict) -> None:
         """Save attempt history to JSON file."""
-        data["metadata"]["last_updated"] = datetime.now().isoformat()
+        data["metadata"]["last_updated"] = datetime.now(timezone.utc).isoformat()
         with open(self.attempt_history_file, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
@@ -130,7 +137,7 @@ class RecoveryManager:
 
     def _save_build_commits(self, data: dict) -> None:
         """Save build commits to JSON file."""
-        data["metadata"]["last_updated"] = datetime.now().isoformat()
+        data["metadata"]["last_updated"] = datetime.now(timezone.utc).isoformat()
         with open(self.build_commits_file, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
@@ -185,17 +192,44 @@ class RecoveryManager:
 
     def get_attempt_count(self, subtask_id: str) -> int:
         """
-        Get how many times this subtask has been attempted.
+        Get how many times this subtask has been attempted within the time window.
+
+        Only counts attempts within ATTEMPT_WINDOW_SECONDS (default: 2 hours).
+        This prevents unbounded accumulation across crash/restart cycles.
 
         Args:
             subtask_id: ID of the subtask
 
         Returns:
-            Number of attempts
+            Number of attempts within the time window
         """
         history = self._load_attempt_history()
         subtask_data = history["subtasks"].get(subtask_id, {})
-        return len(subtask_data.get("attempts", []))
+        attempts = subtask_data.get("attempts", [])
+
+        # Calculate cutoff time for the window
+        cutoff_time = datetime.now(timezone.utc) - timedelta(
+            seconds=ATTEMPT_WINDOW_SECONDS
+        )
+        # For backward compatibility with naive timestamps, also create naive cutoff
+        cutoff_time_naive = datetime.now() - timedelta(seconds=ATTEMPT_WINDOW_SECONDS)
+
+        # Count only attempts within the time window
+        recent_count = 0
+        for attempt in attempts:
+            try:
+                attempt_time = datetime.fromisoformat(attempt["timestamp"])
+                # Use appropriate cutoff based on whether timestamp is naive or aware
+                cutoff = (
+                    cutoff_time_naive if attempt_time.tzinfo is None else cutoff_time
+                )
+                if attempt_time >= cutoff:
+                    recent_count += 1
+            except (KeyError, ValueError):
+                # If timestamp is missing or invalid, count it (backward compatibility)
+                recent_count += 1
+
+        return recent_count
 
     def record_attempt(
         self,
@@ -207,6 +241,8 @@ class RecoveryManager:
     ) -> None:
         """
         Record an attempt at a subtask.
+
+        Automatically trims old attempts if the history exceeds MAX_ATTEMPT_HISTORY_PER_SUBTASK.
 
         Args:
             subtask_id: ID of the subtask
@@ -224,12 +260,23 @@ class RecoveryManager:
         # Add the attempt
         attempt = {
             "session": session,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "approach": approach,
             "success": success,
             "error": error,
         }
         history["subtasks"][subtask_id]["attempts"].append(attempt)
+
+        # Hard cap: trim oldest attempts if we exceed the maximum
+        attempts = history["subtasks"][subtask_id]["attempts"]
+        if len(attempts) > MAX_ATTEMPT_HISTORY_PER_SUBTASK:
+            trimmed_count = len(attempts) - MAX_ATTEMPT_HISTORY_PER_SUBTASK
+            history["subtasks"][subtask_id]["attempts"] = attempts[
+                -MAX_ATTEMPT_HISTORY_PER_SUBTASK:
+            ]
+            logger.debug(
+                f"Trimmed {trimmed_count} old attempts for subtask {subtask_id} (cap: {MAX_ATTEMPT_HISTORY_PER_SUBTASK})"
+            )
 
         # Update status
         if success:
@@ -405,7 +452,7 @@ class RecoveryManager:
         commit_record = {
             "hash": commit_hash,
             "subtask_id": subtask_id,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         commits["commits"].append(commit_record)
@@ -450,7 +497,7 @@ class RecoveryManager:
         stuck_entry = {
             "subtask_id": subtask_id,
             "reason": reason,
-            "escalated_at": datetime.now().isoformat(),
+            "escalated_at": datetime.now(timezone.utc).isoformat(),
             "attempt_count": self.get_attempt_count(subtask_id),
         }
 

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -331,7 +331,9 @@ function createWindow(): void {
   // Clean up on close
   mainWindow.on('closed', () => {
     // Kill all agents when window closes (prevents orphaned processes)
-    agentManager?.killAll?.();
+    agentManager?.killAll?.()?.catch((err: unknown) => {
+      console.warn('[main] Error killing agents on window close:', err);
+    });
     mainWindow = null;
   });
 }

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -330,6 +330,8 @@ function createWindow(): void {
 
   // Clean up on close
   mainWindow.on('closed', () => {
+    // Kill all agents when window closes (prevents orphaned processes)
+    agentManager?.killAll?.();
     mainWindow = null;
   });
 }

--- a/apps/frontend/src/main/ipc-handlers/index.ts
+++ b/apps/frontend/src/main/ipc-handlers/index.ts
@@ -35,6 +35,7 @@ import { registerProfileHandlers } from './profile-handlers';
 import { registerScreenshotHandlers } from './screenshot-handlers';
 import { registerTerminalWorktreeIpcHandlers } from './terminal';
 import { notificationService } from '../notification-service';
+import { setAgentManagerRef } from './utils';
 
 /**
  * Setup all IPC handlers across all domains
@@ -52,6 +53,9 @@ export function setupIpcHandlers(
 ): void {
   // Initialize notification service
   notificationService.initialize(getMainWindow);
+
+  // Wire up agent manager for circuit breaker cleanup
+  setAgentManagerRef(agentManager);
 
   // Project handlers (including Python environment setup)
   registerProjectHandlers(pythonEnvManager, agentManager, getMainWindow);

--- a/apps/frontend/src/main/ipc-handlers/utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/utils.ts
@@ -15,11 +15,11 @@ const WARN_COOLDOWN_MS = 5000; // 5 seconds between warnings per channel
 /** Circuit breaker: kill agents after consecutive renderer disposal errors */
 const MAX_CONSECUTIVE_DISPOSAL_ERRORS = 10;
 let consecutiveDisposalErrors = 0;
-let agentManagerRef: { killAll: () => void } | null = null;
+let agentManagerRef: { killAll: () => void | Promise<void> } | null = null;
 let circuitBreakerTriggered = false;
 
 /** Set agent manager reference for circuit breaker cleanup */
-export function setAgentManagerRef(manager: { killAll: () => void }): void {
+export function setAgentManagerRef(manager: { killAll: () => void | Promise<void> }): void {
   agentManagerRef = manager;
 }
 
@@ -119,8 +119,9 @@ export function safeSendToRenderer(
 
     // All checks passed - safe to send
     mainWindow.webContents.send(channel, ...args);
-    // On successful send, reset circuit breaker counter
+    // On successful send, reset circuit breaker state (allow re-trigger after recovery)
     consecutiveDisposalErrors = 0;
+    circuitBreakerTriggered = false;
     return true;
   } catch (error) {
     // Catch any disposal errors that might occur between our checks and the actual send
@@ -133,7 +134,9 @@ export function safeSendToRenderer(
       if (consecutiveDisposalErrors >= MAX_CONSECUTIVE_DISPOSAL_ERRORS && !circuitBreakerTriggered && agentManagerRef) {
         circuitBreakerTriggered = true;
         console.error('[safeSendToRenderer] Circuit breaker triggered: killing all agents after renderer death');
-        agentManagerRef.killAll();
+        Promise.resolve(agentManagerRef.killAll()).catch((err) => {
+          console.error('[safeSendToRenderer] Error killing agents:', err);
+        });
       }
 
       if (!isWithinCooldown(channel)) {

--- a/apps/frontend/src/main/ipc-handlers/utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/utils.ts
@@ -12,6 +12,17 @@ import type { BrowserWindow } from "electron";
 const warnTimestamps = new Map<string, number>();
 const WARN_COOLDOWN_MS = 5000; // 5 seconds between warnings per channel
 
+/** Circuit breaker: kill agents after consecutive renderer disposal errors */
+const MAX_CONSECUTIVE_DISPOSAL_ERRORS = 10;
+let consecutiveDisposalErrors = 0;
+let agentManagerRef: { killAll: () => void } | null = null;
+let circuitBreakerTriggered = false;
+
+/** Set agent manager reference for circuit breaker cleanup */
+export function setAgentManagerRef(manager: { killAll: () => void }): void {
+  agentManagerRef = manager;
+}
+
 /**
  * Check if a channel is within the warning cooldown period.
  * @returns true if within cooldown (should skip warning), false if cooldown expired
@@ -108,6 +119,8 @@ export function safeSendToRenderer(
 
     // All checks passed - safe to send
     mainWindow.webContents.send(channel, ...args);
+    // On successful send, reset circuit breaker counter
+    consecutiveDisposalErrors = 0;
     return true;
   } catch (error) {
     // Catch any disposal errors that might occur between our checks and the actual send
@@ -115,6 +128,14 @@ export function safeSendToRenderer(
 
     // Only log disposal errors once per channel to avoid log spam
     if (errorMessage.includes("disposed") || errorMessage.includes("destroyed")) {
+      // Circuit breaker: track consecutive disposal errors
+      consecutiveDisposalErrors++;
+      if (consecutiveDisposalErrors >= MAX_CONSECUTIVE_DISPOSAL_ERRORS && !circuitBreakerTriggered && agentManagerRef) {
+        circuitBreakerTriggered = true;
+        console.error('[safeSendToRenderer] Circuit breaker triggered: killing all agents after renderer death');
+        agentManagerRef.killAll();
+      }
+
       if (!isWithinCooldown(channel)) {
         console.warn(`[safeSendToRenderer] Frame disposed, skipping send: ${channel}`);
         recordWarning(channel);

--- a/apps/frontend/src/renderer/hooks/useIpc.ts
+++ b/apps/frontend/src/renderer/hooks/useIpc.ts
@@ -7,6 +7,9 @@ import { useAuthFailureStore } from '../stores/auth-failure-store';
 import { useProjectStore } from '../stores/project-store';
 import type { ImplementationPlan, TaskStatus, RoadmapGenerationStatus, Roadmap, ExecutionProgress, RateLimitInfo, SDKRateLimitInfo, AuthFailureInfo } from '../../shared/types';
 
+/** Maximum log entries to buffer in the batch queue between flushes (OOM prevention) */
+const MAX_BATCH_QUEUE_LOGS = 100;
+
 /**
  * Batched update queue for IPC events.
  * Collects updates within a 16ms window (one frame) and flushes them together.
@@ -124,6 +127,10 @@ function queueUpdate(taskId: string, update: BatchedUpdate): void {
   let mergedLogs = existing.logs;
   if (update.logs) {
     mergedLogs = [...(existing.logs || []), ...update.logs];
+    // Cap batch queue logs to prevent OOM when logs arrive faster than flush interval
+    if (mergedLogs.length > MAX_BATCH_QUEUE_LOGS) {
+      mergedLogs = mergedLogs.slice(-MAX_BATCH_QUEUE_LOGS);
+    }
   }
 
   batchQueue.set(taskId, {

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -7,6 +7,9 @@ import { useProjectStore } from './project-store';
 /** Default max parallel tasks when no project setting is configured */
 export const DEFAULT_MAX_PARALLEL_TASKS = 3;
 
+/** Maximum log entries stored per task to prevent renderer OOM */
+export const MAX_LOG_ENTRIES = 5000;
+
 interface TaskState {
   tasks: Task[];
   selectedTaskId: string | null;
@@ -475,7 +478,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       return {
         tasks: updateTaskAtIndex(state.tasks, index, (t) => ({
           ...t,
-          logs: [...(t.logs || []), log]
+          logs: [...(t.logs || []), log].slice(-MAX_LOG_ENTRIES)
         }))
       };
     }),
@@ -508,7 +511,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       return {
         tasks: updateTaskAtIndex(state.tasks, index, (t) => ({
           ...t,
-          logs: [...(t.logs || []), ...logs]
+          logs: [...(t.logs || []), ...logs].slice(-MAX_LOG_ENTRIES)
         }))
       };
     });

--- a/tests/test_graphiti.py
+++ b/tests/test_graphiti.py
@@ -1,4 +1,5 @@
 """Tests for Graphiti memory integration."""
+import asyncio
 import os
 import pytest
 from pathlib import Path
@@ -529,3 +530,252 @@ class TestGraphitiState:
         assert len(state.error_log) == 10
         assert "Error 5" in state.error_log[0]["error"]
         assert "Error 14" in state.error_log[-1]["error"]
+
+
+# =============================================================================
+# LADYBUGDB LOCK RETRY LOGIC TESTS
+# =============================================================================
+
+
+class TestIsLockError:
+    """Tests for _is_lock_error lock detection function."""
+
+    def test_lock_file_error_detected(self):
+        """Detects lock + file pattern in error messages."""
+        from integrations.graphiti.queries_pkg.client import _is_lock_error
+
+        assert _is_lock_error(Exception("Could not set lock on file")) is True
+
+    def test_lock_database_error_detected(self):
+        """Detects lock + database pattern in error messages."""
+        from integrations.graphiti.queries_pkg.client import _is_lock_error
+
+        assert _is_lock_error(Exception("Database lock contention detected")) is True
+
+    def test_could_not_set_lock_detected(self):
+        """Detects 'could not set lock' pattern."""
+        from integrations.graphiti.queries_pkg.client import _is_lock_error
+
+        assert _is_lock_error(Exception("could not set lock")) is True
+
+    def test_non_lock_error_not_detected(self):
+        """Non-lock errors are not detected as lock errors."""
+        from integrations.graphiti.queries_pkg.client import _is_lock_error
+
+        assert _is_lock_error(Exception("Connection refused")) is False
+        assert _is_lock_error(Exception("Timeout error")) is False
+        assert _is_lock_error(Exception("Permission denied")) is False
+
+    def test_lock_without_file_or_database_not_detected(self):
+        """'lock' alone without 'file' or 'database' is not detected."""
+        from integrations.graphiti.queries_pkg.client import _is_lock_error
+
+        # 'lock' without 'file' or 'database' and no 'could not set lock'
+        assert _is_lock_error(Exception("Object is locked by user")) is False
+
+
+class TestBackoffWithJitter:
+    """Tests for _backoff_with_jitter calculation."""
+
+    def test_backoff_increases_with_attempt(self):
+        """Backoff time increases with attempt number."""
+        from integrations.graphiti.queries_pkg.client import _backoff_with_jitter
+
+        # Run multiple times to account for jitter
+        attempt_0_values = [_backoff_with_jitter(0) for _ in range(20)]
+        attempt_3_values = [_backoff_with_jitter(3) for _ in range(20)]
+
+        avg_0 = sum(attempt_0_values) / len(attempt_0_values)
+        avg_3 = sum(attempt_3_values) / len(attempt_3_values)
+
+        assert avg_3 > avg_0, "Higher attempts should have higher average backoff"
+
+    def test_backoff_is_positive(self):
+        """Backoff is always positive."""
+        from integrations.graphiti.queries_pkg.client import _backoff_with_jitter
+
+        for attempt in range(10):
+            for _ in range(10):
+                assert _backoff_with_jitter(attempt) > 0
+
+    def test_backoff_capped_at_max(self):
+        """Backoff should not exceed MAX_BACKOFF_SECONDS + jitter."""
+        from integrations.graphiti.queries_pkg.client import (
+            JITTER_PERCENT,
+            MAX_BACKOFF_SECONDS,
+            _backoff_with_jitter,
+        )
+
+        max_possible = MAX_BACKOFF_SECONDS * (1 + JITTER_PERCENT)
+        for _ in range(50):
+            val = _backoff_with_jitter(100)  # Very high attempt
+            assert val <= max_possible + 0.01, f"Backoff {val} exceeded max {max_possible}"
+
+
+class TestGraphitiClientRetryLogic:
+    """Tests for LadybugDB lock retry logic in GraphitiClient.initialize().
+
+    These tests exercise the retry loop behavior by mocking the modules
+    that are imported locally inside initialize(). We patch at the source
+    module level since the imports are local to the method.
+    """
+
+    def _make_config(self):
+        """Create a mock GraphitiConfig for testing."""
+        config = MagicMock()
+        config.llm_provider = "openai"
+        config.embedder_provider = "openai"
+        config.get_db_path.return_value = Path("/tmp/test-db")
+        config.get_provider_summary.return_value = "openai/openai"
+        return config
+
+    def _make_mock_providers(self):
+        """Create mock graphiti_providers module."""
+        mock_providers = MagicMock()
+        mock_providers.create_llm_client = MagicMock(return_value=MagicMock())
+        mock_providers.create_embedder = MagicMock(return_value=MagicMock())
+        mock_providers.ProviderError = type("ProviderError", (Exception,), {})
+        mock_providers.ProviderNotInstalled = type(
+            "ProviderNotInstalled", (mock_providers.ProviderError,), {}
+        )
+        return mock_providers
+
+    def _make_noop_sleep(self):
+        """Create an async no-op replacement for asyncio.sleep."""
+        async def _noop_sleep(_delay):
+            return
+
+        return _noop_sleep
+
+    @pytest.mark.asyncio
+    async def test_successful_retry_after_lock_error(self):
+        """Client retries and succeeds after transient lock error."""
+        from integrations.graphiti.queries_pkg.client import GraphitiClient
+
+        config = self._make_config()
+        client = GraphitiClient(config)
+
+        call_count = 0
+
+        def mock_create_driver(db=""):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("Could not set lock on file /tmp/test-db")
+            return MagicMock()
+
+        mock_graphiti_instance = MagicMock()
+
+        async def mock_build_indices():
+            pass
+
+        mock_graphiti_instance.build_indices_and_constraints = mock_build_indices
+
+        mock_graphiti_cls = MagicMock(return_value=mock_graphiti_instance)
+        mock_graphiti_core = MagicMock()
+        mock_graphiti_core.Graphiti = mock_graphiti_cls
+
+        mock_kuzu_driver = MagicMock()
+        mock_kuzu_driver.create_patched_kuzu_driver = mock_create_driver
+
+        with (
+            patch.dict(sys.modules, {
+                "graphiti_core": mock_graphiti_core,
+                "graphiti_providers": self._make_mock_providers(),
+                "integrations.graphiti.queries_pkg.kuzu_driver_patched": mock_kuzu_driver,
+            }),
+            patch(
+                "integrations.graphiti.queries_pkg.client._apply_ladybug_monkeypatch",
+                return_value=True,
+            ),
+            patch(
+                "integrations.graphiti.queries_pkg.client.asyncio.sleep",
+                side_effect=self._make_noop_sleep(),
+            ),
+        ):
+            result = await client.initialize()
+
+        assert call_count == 2, "Should have retried once after lock error"
+        assert result is True, "Should succeed after retry"
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_returns_false(self):
+        """Client returns False after exhausting all retries on lock errors."""
+        from integrations.graphiti.queries_pkg.client import (
+            MAX_LOCK_RETRIES,
+            GraphitiClient,
+        )
+
+        config = self._make_config()
+        client = GraphitiClient(config)
+
+        call_count = 0
+
+        def always_lock_error(db=""):
+            nonlocal call_count
+            call_count += 1
+            raise OSError("Could not set lock on database file")
+
+        mock_kuzu_driver = MagicMock()
+        mock_kuzu_driver.create_patched_kuzu_driver = always_lock_error
+
+        with (
+            patch.dict(sys.modules, {
+                "graphiti_core": MagicMock(),
+                "graphiti_providers": self._make_mock_providers(),
+                "integrations.graphiti.queries_pkg.kuzu_driver_patched": mock_kuzu_driver,
+            }),
+            patch(
+                "integrations.graphiti.queries_pkg.client._apply_ladybug_monkeypatch",
+                return_value=True,
+            ),
+            patch(
+                "integrations.graphiti.queries_pkg.client.capture_exception",
+            ),
+            patch(
+                "integrations.graphiti.queries_pkg.client.asyncio.sleep",
+                side_effect=self._make_noop_sleep(),
+            ),
+        ):
+            result = await client.initialize()
+
+        assert result is False, "Should return False after exhausting retries"
+        # Should attempt MAX_LOCK_RETRIES + 1 times (initial + retries)
+        assert call_count == MAX_LOCK_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_non_lock_error_fails_immediately(self):
+        """Non-lock errors cause immediate failure without retry."""
+        from integrations.graphiti.queries_pkg.client import GraphitiClient
+
+        config = self._make_config()
+        client = GraphitiClient(config)
+
+        call_count = 0
+
+        def connection_error(db=""):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Connection refused - server not running")
+
+        mock_kuzu_driver = MagicMock()
+        mock_kuzu_driver.create_patched_kuzu_driver = connection_error
+
+        with (
+            patch.dict(sys.modules, {
+                "graphiti_core": MagicMock(),
+                "graphiti_providers": self._make_mock_providers(),
+                "integrations.graphiti.queries_pkg.kuzu_driver_patched": mock_kuzu_driver,
+            }),
+            patch(
+                "integrations.graphiti.queries_pkg.client._apply_ladybug_monkeypatch",
+                return_value=True,
+            ),
+            patch(
+                "integrations.graphiti.queries_pkg.client.capture_exception",
+            ),
+        ):
+            result = await client.initialize()
+
+        assert call_count == 1, "Non-lock errors should not trigger retries"
+        assert result is False


### PR DESCRIPTION
## Summary

Addresses multiple crash and stability issues observed during long-running overnight autonomous builds. Prevents memory exhaustion, orphaned agent processes, and unbounded data accumulation.

## Problem

During extended autonomous build sessions (overnight), several failure modes were observed:
1. **OOM crashes** — Unbounded log accumulation in renderer stores and IPC batch queues
2. **Orphaned agent processes** — Agents keep running after the Electron window closes or renderer dies
3. **LadybugDB lock contention** — Parallel agents competing for database locks cause initialization failures
4. **Stuck subtask loops** — Recovery manager retries stuck subtasks indefinitely, accumulating unbounded attempt history
5. **Stale attempt counts** — Old attempts from previous sessions inflate retry counts, causing premature "stuck" classification

## Solution

### Backend
- **Stuck subtask skipping** (`progress.py`) — `get_next_subtask()` reads `attempt_history.json` and skips subtasks marked as stuck, preventing infinite retry loops
- **LadybugDB lock retry** (`client.py`) — Exponential backoff with jitter (up to 5 retries, max 8s backoff) for database lock contention during `initialize()`
- **Time-window attempt filtering** (`recovery.py`) — `get_attempt_count()` only counts attempts within a 2-hour sliding window, preventing stale accumulation across crash/restart cycles
- **Attempt history trimming** (`recovery.py`) — Hard cap of 50 attempts per subtask with oldest-first eviction
- **Timezone-aware timestamps** (`recovery.py`) — All new timestamps use UTC for consistent cross-timezone comparison, with backward compatibility for existing naive timestamps

### Frontend
- **Agent cleanup on close** (`index.ts`) — Calls `agentManager.killAll()` when the main window closes
- **Circuit breaker** (`utils.ts`) — Kills all agents after 10 consecutive renderer disposal errors, preventing orphaned processes when the renderer dies
- **Batch queue log cap** (`useIpc.ts`) — Caps IPC batch queue at 100 log entries per flush cycle
- **Task log cap** (`task-store.ts`) — Caps stored logs at 5,000 entries per task

## Changes

| File | Change |
|------|--------|
| `apps/backend/core/progress.py` | Skip stuck subtasks in `get_next_subtask()` |
| `apps/backend/integrations/graphiti/queries_pkg/client.py` | Retry loop with exponential backoff for lock contention |
| `apps/backend/services/recovery.py` | Time-window filtering, attempt trimming, UTC timestamps |
| `apps/frontend/src/main/index.ts` | Kill agents on window close |
| `apps/frontend/src/main/ipc-handlers/index.ts` | Wire agent manager ref for circuit breaker |
| `apps/frontend/src/main/ipc-handlers/utils.ts` | Circuit breaker for renderer disposal errors |
| `apps/frontend/src/renderer/hooks/useIpc.ts` | Cap batch queue logs at 100 |
| `apps/frontend/src/renderer/stores/task-store.ts` | Cap task logs at 5,000 |
| `tests/test_graphiti.py` | Lock detection, backoff calculation, retry logic tests |
| `tests/test_implementation_plan.py` | Stuck subtask skipping tests |
| `tests/test_recovery.py` | Time-window filtering, trimming, boundary tests |

## Testing

- [x] All 2,061 backend tests pass
- [x] Biome lint clean on all frontend changes
- [x] Ruff lint + format clean on all backend changes
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Cross-Platform Compatibility

No platform-specific code introduced. All changes use existing cross-platform abstractions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added retry/backoff for database initialization to handle lock contention
  * Fixed cleanup on app exit to terminate background agents
  * Improved logging and timezone-aware timestamps; trimmed per-subtask attempt history to prevent unbounded growth

* **New Features**
  * Recovery improvements to skip/handle stuck subtasks and provide structured recovery actions
  * Circuit-breaker to stop cascading failures by terminating agents after repeated renderer disposal errors
  * Caps on renderer log batching and per-task log history to avoid OOM

* **Tests**
  * New test suites covering lock-retry, stuck-subtask skipping, and recovery/time-window behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FAndyMik90%2FAuto-Claude%2Fpull%2F1813&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->