### PR TITLE
fix: resolve Kanban board stuck task state synchronization

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
@@ -100,10 +100,10 @@ export function registerAgenteventsHandlers(
     // force it to human_review after a short delay. This prevents tasks from getting stuck
     // in in_progress state when the process exits without XState properly handling it.
     setTimeout(() => {
-      const { task: checkTask } = findTaskAndProject(taskId, projectId);
-      if (checkTask && checkTask.status === 'in_progress') {
-        console.warn(`[agent-events-handlers] Task ${taskId} still in_progress 500ms after exit, forcing to human_review`);
-        taskStateManager.forceTransition(taskId, 'human_review', 'errors', checkTask, exitProject);
+      const { task: checkTask, project: checkProject } = findTaskAndProject(taskId, projectId);
+      if (checkTask && checkTask.status === 'in_progress' && checkProject) {
+        console.warn(`[agent-events-handlers] Task ${taskId} still in_progress 500ms after exit, forcing USER_STOPPED`);
+        taskStateManager.handleUiEvent(taskId, { type: 'USER_STOPPED', hasPlan: true }, checkTask, checkProject);
       }
     }, 500);
 

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -15,12 +15,14 @@ import {
   getPlanPath,
   persistPlanStatus,
   createPlanIfNotExists,
-  resetStuckSubtasks
+  resetStuckSubtasks,
+  hasPlanWithSubtasks
 } from './plan-file-utils';
 import { writeFileAtomicSync } from '../../utils/atomic-file';
 import { findTaskWorktree } from '../../worktree-paths';
 import { projectStore } from '../../project-store';
 import { getIsolatedGitEnv, detectWorktreeBranch } from '../../utils/git-isolation';
+import { cancelFallbackTimer } from '../agent-events-handlers';
 
 /**
  * Safe file read that handles missing files without TOCTOU issues.
@@ -95,6 +97,11 @@ export function registerTaskExecutionHandlers(
     IPC_CHANNELS.TASK_START,
     async (_, taskId: string, _options?: TaskStartOptions) => {
       console.warn('[TASK_START] Received request for taskId:', taskId);
+
+      // Cancel any pending fallback timer from previous process exit
+      // This prevents the stale timer from incorrectly stopping the newly restarted task
+      cancelFallbackTimer(taskId);
+
       const mainWindow = getMainWindow();
       if (!mainWindow) {
         console.warn('[TASK_START] No main window found');
@@ -296,18 +303,8 @@ export function registerTaskExecutionHandlers(
 
     if (!task || !project) return;
 
-    let hasPlan = false;
-    try {
-      const planPath = getPlanPath(project, task);
-      const planContent = safeReadFileSync(planPath);
-      if (planContent) {
-        const plan = JSON.parse(planContent);
-        const { totalCount } = checkSubtasksCompletion(plan);
-        hasPlan = totalCount > 0;
-      }
-    } catch {
-      hasPlan = false;
-    }
+    // Use shared utility to determine if a valid implementation plan exists
+    const hasPlan = hasPlanWithSubtasks(project, task);
 
     taskStateManager.handleUiEvent(
       taskId,

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -699,6 +699,10 @@ export function registerTaskExecutionHandlers(
 
           console.warn('[TASK_UPDATE_STATUS] Auto-starting task:', taskId);
 
+          // Cancel any pending fallback timer from previous process exit
+          // This prevents the stale timer from incorrectly stopping the newly started task
+          cancelFallbackTimer(taskId);
+
           // Reset any stuck subtasks before starting execution
           // This handles recovery from previous rate limits or crashes
           const resetResult = await resetStuckSubtasks(planPath, project.id);
@@ -1117,6 +1121,10 @@ export function registerTaskExecutionHandlers(
           }
 
           try {
+            // Cancel any pending fallback timer from previous process exit
+            // This prevents the stale timer from incorrectly stopping the restarted task
+            cancelFallbackTimer(taskId);
+
             // Set status to in_progress for the restart
             newStatus = 'in_progress';
 

--- a/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
@@ -538,3 +538,30 @@ export function updateTaskMetadataPrUrl(metadataPath: string, prUrl: string): bo
     return false;
   }
 }
+
+/**
+ * Check if a task has a valid implementation plan with subtasks.
+ * A plan is considered valid if it has at least one subtask across all phases.
+ *
+ * @param project - The project containing the task
+ * @param task - The task to check
+ * @returns true if the task has a valid plan with subtasks, false otherwise
+ */
+export function hasPlanWithSubtasks(project: Project, task: Task): boolean {
+  try {
+    const planPath = getPlanPath(project, task);
+    const planContent = readFileSync(planPath, 'utf-8');
+    if (!planContent) {
+      return false;
+    }
+
+    const plan = JSON.parse(planContent);
+    // A plan exists if it has phases with subtasks (totalCount > 0)
+    const phases = plan.phases as Array<{ subtasks?: Array<unknown> }> | undefined;
+    const totalCount = phases?.flatMap(p => p.subtasks || []).length || 0;
+    return totalCount > 0;
+  } catch {
+    // File doesn't exist or is malformed
+    return false;
+  }
+}

--- a/apps/frontend/src/renderer/components/SortableTaskCard.tsx
+++ b/apps/frontend/src/renderer/components/SortableTaskCard.tsx
@@ -41,7 +41,10 @@ export const SortableTaskCard = memo(function SortableTaskCard({ task, onClick, 
     transition,
     isDragging,
     isOver
-  } = useSortable({ id: task.id });
+  } = useSortable({
+    id: task.id,
+    disabled: task.status === 'in_progress' // Prevent dragging tasks that are currently running or stuck
+  });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/apps/frontend/src/renderer/components/TaskCard.tsx
+++ b/apps/frontend/src/renderer/components/TaskCard.tsx
@@ -228,7 +228,9 @@ export const TaskCard = memo(function TaskCard({
 
   const handleStartStop = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (isRunning && !isStuck) {
+    if (isRunning) {
+      // Allow stopping both running and stuck tasks
+      // User should be able to force-stop a stuck task
       stopTask(task.id);
     } else {
       const result = await startTaskOrQueue(task.id);

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -309,6 +309,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
             // When starting a task and no phase is set yet, default to planning
             // This prevents the "no active phase" UI state during startup race condition
             executionProgress = { phase: 'planning' as ExecutionPhase, phaseProgress: 0, overallProgress: 0 };
+          } else if (status === 'human_review' || status === 'error' || status === 'done' || status === 'pr_created') {
+            // Reset execution progress when task reaches terminal states
+            // This prevents stuck tasks from showing stale progress indicators
+            executionProgress = { phase: 'idle' as ExecutionPhase, phaseProgress: 0, overallProgress: 0 };
           }
 
           // Log status transitions to help diagnose flip-flop issues

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -309,7 +309,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
             // When starting a task and no phase is set yet, default to planning
             // This prevents the "no active phase" UI state during startup race condition
             executionProgress = { phase: 'planning' as ExecutionPhase, phaseProgress: 0, overallProgress: 0 };
-          } else if (status === 'human_review' || status === 'error' || status === 'done' || status === 'pr_created') {
+          } else if (['human_review', 'error', 'done', 'pr_created'].includes(status)) {
             // Reset execution progress when task reaches terminal states
             // This prevents stuck tasks from showing stale progress indicators
             executionProgress = { phase: 'idle' as ExecutionPhase, phaseProgress: 0, overallProgress: 0 };

--- a/apps/frontend/src/shared/state-machines/index.ts
+++ b/apps/frontend/src/shared/state-machines/index.ts
@@ -3,6 +3,7 @@ export type { TaskContext, TaskEvent } from './task-machine';
 export {
   TASK_STATE_NAMES,
   XSTATE_SETTLED_STATES,
+  XSTATE_ACTIVE_STATES,
   XSTATE_TO_PHASE,
   mapStateToLegacy,
 } from './task-state-utils';

--- a/apps/frontend/src/shared/state-machines/task-state-utils.ts
+++ b/apps/frontend/src/shared/state-machines/task-state-utils.ts
@@ -36,6 +36,14 @@ export const XSTATE_SETTLED_STATES: ReadonlySet<string> = new Set<TaskStateName>
   'plan_review', 'human_review', 'error', 'creating_pr', 'pr_created', 'done'
 ]);
 
+/**
+ * XState states where an agent process is actively running and should transition
+ * when the process exits. Used by the fallback safety net to detect stuck tasks.
+ */
+export const XSTATE_ACTIVE_STATES: ReadonlySet<string> = new Set<TaskStateName>([
+  'planning', 'coding', 'qa_review', 'qa_fixing'
+]);
+
 /** Maps XState states to execution phases. */
 export const XSTATE_TO_PHASE: Record<TaskStateName, ExecutionPhase> & Record<string, ExecutionPhase | undefined> = {
   'backlog': 'idle',


### PR DESCRIPTION
## Summary
- Fix state synchronization gap between backend process lifecycle and frontend XState state machine that caused tasks to get stuck spinning forever in the Kanban UI
- Reset execution progress when tasks transition to terminal states (human_review, error, done, pr_created)
- Propagate final phase updates to renderer even after XState settles
- Add 500ms fallback in exit handler to force transition if task remains in_progress
- Disable dragging for in_progress tasks to prevent state conflicts
- Allow force-stopping stuck tasks (previously the stop button was disabled when stuck)

## Test plan
- [ ] Start an agent task and let it complete — verify task transitions cleanly to human_review
- [ ] Kill an agent process mid-run — verify task doesn't get stuck, transitions to human_review after fallback
- [ ] Attempt to drag an in_progress task — verify dragging is disabled
- [ ] Trigger a stuck task scenario — verify the stop button works and forces the task out of in_progress
- [ ] Verify normal task lifecycle (backlog → in_progress → human_review → done) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dragging of tasks that are currently in progress.
  * Enabled force-stopping of tasks even when marked as stuck.
  * Progress indicators now reset when tasks reach terminal states.
  * Final-phase updates are reliably shown without UI flicker after state transitions.
  * Added a fallback after process exit to ensure stuck/running tasks transition to a stopped state when appropriate.

* **Improvements**
  * Avoids overwriting persisted plan phases when a task is already terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->