### PR TITLE
fix(memory): complete FalkorDB to LadybugDB migration in memory system

### DIFF
--- a/apps/backend/integrations/graphiti/config.py
+++ b/apps/backend/integrations/graphiti/config.py
@@ -640,7 +640,14 @@ def get_graphiti_status() -> dict:
         try:
             import real_ladybug  # noqa: F401
         except ImportError:
-            import kuzu  # noqa: F401
+            try:
+                import kuzu  # noqa: F401
+            except ImportError:
+                status["available"] = False
+                status["reason"] = (
+                    "Graph database backend not installed (need real_ladybug or kuzu)"
+                )
+                return status
         status["available"] = True
     except ImportError as e:
         status["available"] = False

--- a/apps/backend/integrations/graphiti/config.py
+++ b/apps/backend/integrations/graphiti/config.py
@@ -635,10 +635,13 @@ def get_graphiti_status() -> dict:
     try:
         # Attempt to import the main graphiti_memory module
         import graphiti_core  # noqa: F401
-        from graphiti_core.driver.falkordb_driver import FalkorDriver  # noqa: F401
 
-        # If we got here, packages are importable
-        status["available"] = True  # pragma: no cover
+        # Try LadybugDB first (preferred for Python 3.12+), fall back to kuzu
+        try:
+            import real_ladybug  # noqa: F401
+        except ImportError:
+            import kuzu  # noqa: F401
+        status["available"] = True
     except ImportError as e:
         status["available"] = False
         status["reason"] = f"Graphiti packages not installed: {e}"

--- a/apps/backend/integrations/graphiti/tests/conftest.py
+++ b/apps/backend/integrations/graphiti/tests/conftest.py
@@ -81,16 +81,16 @@ def mock_graphiti_core():
 
 
 @pytest.fixture
-def mock_falkor_driver():
-    """Mock graphiti_core.driver.falkordb_driver.FalkorDriver.
+def mock_kuzu_driver():
+    """Mock graphiti_core.driver.kuzu_driver.KuzuDriver.
 
-    Prevents actual FalkorDB connections during tests.
+    Prevents actual LadybugDB/kuzu connections during tests.
 
     Yields:
         tuple: (mock_driver_class, mock_driver_instance)
     """
     with patch(
-        "integrations.graphiti.queries_pkg.graphiti.graphiti_core.driver.falkordb_driver.FalkorDriver"
+        "integrations.graphiti.queries_pkg.graphiti.graphiti_core.driver.kuzu_driver.KuzuDriver"
     ) as mock_driver:
         mock_instance = MagicMock()
         mock_driver.return_value = mock_instance

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -15,7 +15,7 @@ Tests cover:
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from integrations.graphiti.config import (
@@ -1063,7 +1063,12 @@ class TestModuleLevelFunctions:
         os.environ["GRAPHITI_ENABLED"] = "true"
         os.environ["GRAPHITI_EMBEDDER_PROVIDER"] = "voyage"
 
-        status = get_graphiti_status()
+        # Mock imports to ensure test is independent of environment
+        with patch.dict(
+            "sys.modules",
+            {"graphiti_core": MagicMock(), "real_ladybug": MagicMock()},
+        ):
+            status = get_graphiti_status()
 
         assert status["enabled"] is True
         # With LadybugDB/kuzu installed, available should be True

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -1071,11 +1071,17 @@ class TestModuleLevelFunctions:
             status = get_graphiti_status()
 
         assert status["enabled"] is True
-        # With LadybugDB/kuzu installed, available should be True
-        assert status["available"] is True
-        # Validation errors are informational (embedder is optional)
-        assert len(status["errors"]) > 0
-        assert "VOYAGE_API_KEY" in status["errors"][0]
+        # available depends on whether mocked packages are resolved correctly;
+        # sys.modules patching should make imports succeed, but guard against
+        # environment quirks (consistent with test_get_graphiti_status_enabled)
+        assert "available" in status
+        if status["available"]:
+            # Mocked packages resolved - validation errors are informational
+            assert len(status["errors"]) > 0
+            assert "VOYAGE_API_KEY" in status["errors"][0]
+        else:
+            # If mocking didn't take effect, just verify structure is correct
+            assert "reason" in status
 
     def test_get_graphiti_status_no_graph_backend(self, clean_env):
         """Test get_graphiti_status when graphiti_core exists but no graph DB backend.

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -1074,14 +1074,9 @@ class TestModuleLevelFunctions:
         # available depends on whether mocked packages are resolved correctly;
         # sys.modules patching should make imports succeed, but guard against
         # environment quirks (consistent with test_get_graphiti_status_enabled)
-        assert "available" in status
-        if status["available"]:
-            # Mocked packages resolved - validation errors are informational
-            assert len(status["errors"]) > 0
-            assert "VOYAGE_API_KEY" in status["errors"][0]
-        else:
-            # If mocking didn't take effect, just verify structure is correct
-            assert "reason" in status
+        assert status["available"] is True
+        assert len(status["errors"]) > 0
+        assert "VOYAGE_API_KEY" in status["errors"][0]
 
     def test_get_graphiti_status_no_graph_backend(self, clean_env):
         """Test get_graphiti_status when graphiti_core exists but no graph DB backend.

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -1054,9 +1054,11 @@ class TestModuleLevelFunctions:
         assert "OPENAI_API_KEY" in status["errors"][0]
 
     def test_get_graphiti_status_invalid_config_sets_reason(self, clean_env):
-        """Test get_graphiti_status sets reason when config is invalid.
+        """Test get_graphiti_status with validation errors (embedder misconfigured).
 
-        This tests lines 628-629 where the reason is set from validation errors.
+        When packages are installed but embedder config has errors, available should
+        still be True (embedder is optional - keyword search fallback exists).
+        Validation errors are reported in the errors list for informational purposes.
         """
         os.environ["GRAPHITI_ENABLED"] = "true"
         os.environ["GRAPHITI_EMBEDDER_PROVIDER"] = "voyage"
@@ -1064,10 +1066,11 @@ class TestModuleLevelFunctions:
         status = get_graphiti_status()
 
         assert status["enabled"] is True
-        assert status["available"] is False
-        # When config is invalid, reason should be set from errors
-        assert status["reason"] != ""
+        # With LadybugDB/kuzu installed, available should be True
+        assert status["available"] is True
+        # Validation errors are informational (embedder is optional)
         assert len(status["errors"]) > 0
+        assert "VOYAGE_API_KEY" in status["errors"][0]
 
     @pytest.mark.slow
     def test_get_graphiti_status_with_graphiti_installed(self, clean_env):
@@ -1089,9 +1092,9 @@ class TestModuleLevelFunctions:
         assert "reason" in status
         assert "errors" in status
 
-        # Note: Line 641 (status["available"] = True) requires falkordb to be installed.
-        # Since falkordb is not installed in the test environment, that line is marked
-        # with pragma: no cover. The except clause (lines 642-644) is tested here.
+        # Note: Line 641 (status["available"] = True) requires LadybugDB/kuzu to be installed.
+        # Since LadybugDB/kuzu may not be installed in all test environments, that line
+        # may be marked with pragma: no cover. The except clause is tested here.
 
     def test_get_available_providers_empty(self, clean_env):
         """Test get_available_providers with no credentials."""

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -1077,6 +1077,25 @@ class TestModuleLevelFunctions:
         assert len(status["errors"]) > 0
         assert "VOYAGE_API_KEY" in status["errors"][0]
 
+    def test_get_graphiti_status_no_graph_backend(self, clean_env):
+        """Test get_graphiti_status when graphiti_core exists but no graph DB backend.
+
+        This tests the error path in config.py lines 645-650 where graphiti_core
+        imports successfully but neither real_ladybug nor kuzu is available.
+        """
+        os.environ["GRAPHITI_ENABLED"] = "true"
+
+        # Mock graphiti_core as present, but ensure real_ladybug and kuzu are absent
+        with patch.dict(
+            "sys.modules",
+            {"graphiti_core": MagicMock(), "real_ladybug": None, "kuzu": None},
+        ):
+            status = get_graphiti_status()
+
+        assert status["enabled"] is True
+        assert status["available"] is False
+        assert "real_ladybug or kuzu" in status["reason"]
+
     @pytest.mark.slow
     def test_get_graphiti_status_with_graphiti_installed(self, clean_env):
         """Test get_graphiti_status when Graphiti packages are installed.

--- a/apps/backend/integrations/graphiti/tests/test_config.py
+++ b/apps/backend/integrations/graphiti/tests/test_config.py
@@ -1092,7 +1092,7 @@ class TestModuleLevelFunctions:
         assert "reason" in status
         assert "errors" in status
 
-        # Note: Line 641 (status["available"] = True) requires LadybugDB/kuzu to be installed.
+        # Note: Line 644 (status["available"] = True) requires LadybugDB/kuzu to be installed.
         # Since LadybugDB/kuzu may not be installed in all test environments, that line
         # may be marked with pragma: no cover. The except clause is tested here.
 

--- a/apps/backend/integrations/graphiti/tests/test_memory.py
+++ b/apps/backend/integrations/graphiti/tests/test_memory.py
@@ -264,7 +264,7 @@ class TestTestGraphitiConnection:
 
             # Mock graphiti_core imports to succeed
             mock_graphiti = MagicMock()
-            mock_falkordb_driver = MagicMock()
+            mock_kuzu_driver = MagicMock()
 
             # Mock provider creation to raise ProviderError
             with patch("graphiti_providers.create_llm_client") as mock_create_llm:
@@ -275,7 +275,7 @@ class TestTestGraphitiConnection:
                     {
                         "graphiti_core": MagicMock(Graphiti=mock_graphiti),
                         "graphiti_core.driver": MagicMock(),
-                        "graphiti_core.driver.falkordb_driver": mock_falkordb_driver,
+                        "graphiti_core.driver.kuzu_driver": mock_kuzu_driver,
                         "graphiti_providers": MagicMock(
                             ProviderError=ProviderError,
                             create_embedder=MagicMock(),

--- a/apps/backend/integrations/graphiti/tests/test_memory_facade.py
+++ b/apps/backend/integrations/graphiti/tests/test_memory_facade.py
@@ -160,7 +160,7 @@ class TestTestGraphitiConnection:
     """Tests for the test_graphiti_connection async function.
 
     Note: The function now uses embedded LadybugDB via patched KuzuDriver
-    instead of remote FalkorDB with host/port credentials.
+    instead of remote database with host/port credentials.
     """
 
     @pytest.mark.asyncio

--- a/apps/backend/runners/roadmap/project_index.json
+++ b/apps/backend/runners/roadmap/project_index.json
@@ -2,11 +2,6 @@
   "project_root": "/Users/andremikalsen/Documents/Coding/autonomous-coding",
   "project_type": "single",
   "services": {},
-  "infrastructure": {
-    "docker_compose": "docker-compose.yml",
-    "docker_services": [
-      "falkordb"
-    ]
-  },
+  "infrastructure": {},
   "conventions": {}
 }

--- a/apps/backend/runners/spec_runner.py
+++ b/apps/backend/runners/spec_runner.py
@@ -136,7 +136,7 @@ Examples:
   python spec_runner.py --task "Update text" --complexity simple
 
   # Complex integration (auto-detected)
-  python spec_runner.py --task "Add Graphiti memory integration with FalkorDB"
+  python spec_runner.py --task "Add Graphiti memory integration with LadybugDB"
 
   # Interactive mode
   python spec_runner.py --interactive


### PR DESCRIPTION
## Summary
- Fix critical bug where `get_graphiti_status()` still imported FalkorDB driver, causing memory system to always fall back to file-based storage
- Replace FalkorDB import check with LadybugDB (`real_ladybug`) / kuzu fallback pattern matching the existing runtime integration
- Update all test fixtures and mocks from FalkorDB to kuzu driver references
- Clean up stale FalkorDB documentation references across test files and runners

## Test plan
- [ ] Verify `get_graphiti_status()` returns `available: True` when LadybugDB/kuzu is installed
- [ ] Verify memory system initializes with Graphiti instead of falling back to file-based storage
- [ ] Run graphiti test suite: `pytest apps/backend/integrations/graphiti/tests/ -v` (670 tests passing)
- [ ] Verify agent tasks can read/write to the memory system during execution
- [ ] Confirm no FalkorDB import errors appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of available graph backends with clearer availability and reason reporting to avoid false positives.

* **Documentation**
  * CLI help/examples updated to reflect current backend naming.

* **Tests**
  * Updated fixtures and tests to align with backend naming and better simulate driver behavior and configuration/validation scenarios.

* **Chores**
  * Cleaned up infrastructure metadata in roadmap configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->