### PR TITLE
fix: clear terminalEventSeen on task restart to prevent stuck-after-planning (#1828)

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -177,6 +177,11 @@ export function registerTaskExecutionHandlers(
 
       console.warn('[TASK_START] Found task:', task.specId, 'status:', task.status, 'reviewReason:', task.reviewReason, 'subtasks:', task.subtasks.length);
 
+      // Clear stale tracking state from any previous execution so that:
+      // - terminalEventSeen doesn't suppress future PROCESS_EXITED events
+      // - lastSequenceByTask doesn't drop events from the new process
+      taskStateManager.prepareForRestart(taskId);
+
       // Check if implementation_plan.json has valid subtasks BEFORE XState handling.
       // This is more reliable than task.subtasks.length which may not be loaded yet.
       const specsBaseDir = getSpecsDir(project.autoBuildPath);
@@ -360,6 +365,9 @@ export function registerTaskExecutionHandlers(
       task,
       project
     );
+
+    // Clear stale tracking state so a subsequent restart works correctly
+    taskStateManager.prepareForRestart(taskId);
   });
 
   /**
@@ -703,6 +711,8 @@ export function registerTaskExecutionHandlers(
 
         // Auto-start task when status changes to 'in_progress' and no process is running
         if (status === 'in_progress' && !agentManager.isRunning(taskId)) {
+          // Clear stale tracking state before starting a new process
+          taskStateManager.prepareForRestart(taskId);
           const mainWindow = getMainWindow();
 
           // Check git status before auto-starting
@@ -1133,6 +1143,8 @@ export function registerTaskExecutionHandlers(
         // Auto-restart the task if requested
         let autoRestarted = false;
         if (autoRestart) {
+          // Clear stale tracking state before restarting
+          taskStateManager.prepareForRestart(taskId);
           // Check git status before auto-restarting
           const gitStatusForRestart = checkGitStatus(project.path);
           if (!gitStatusForRestart.isGitRepo || !gitStatusForRestart.hasCommits) {

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -537,6 +537,9 @@ export function registerTaskExecutionHandlers(
           return { success: false, error: 'Failed to write QA fix request file' };
         }
 
+        // Clear stale tracking state before starting new QA process
+        taskStateManager.prepareForRestart(taskId);
+
         // Restart QA process - use worktree path if it exists, otherwise main project
         // The QA process needs to run where the implementation_plan.json with completed subtasks is
         const qaProjectPath = hasWorktree ? worktreePath : project.path;

--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -169,6 +169,18 @@ export class TaskStateManager {
     return this.getCurrentState(taskId) === 'plan_review';
   }
 
+  /**
+   * Reset tracking state for a task that is about to be restarted.
+   * Clears terminalEventSeen (so process exits aren't swallowed) and
+   * lastSequenceByTask (so events from the new process aren't dropped
+   * as duplicates). Does NOT stop or remove the XState actor, since
+   * the caller may still need to send events to it.
+   */
+  prepareForRestart(taskId: string): void {
+    this.terminalEventSeen.delete(taskId);
+    this.lastSequenceByTask.delete(taskId);
+  }
+
   clearTask(taskId: string): void {
     this.lastSequenceByTask.delete(taskId);
     this.lastStateByTask.delete(taskId);


### PR DESCRIPTION
## Summary

Fixes the root cause of tasks getting permanently stuck after the planning stage completes. The `terminalEventSeen` Set in `TaskStateManager` was never cleared when a task was restarted, causing `handleProcessExited()` to silently swallow `PROCESS_EXITED` events. The XState actor never received the transition, leaving the task permanently stuck in the 'coding' state with no way to recover.

**Root cause:** When `spec_runner.py` emits `PLANNING_COMPLETE` (a terminal event), `terminalEventSeen.add(taskId)` is called. If the subsequent coding process (`run.py`) fails or crashes, `handleProcessExited()` checks `terminalEventSeen.has(taskId)` and returns early, never sending `PROCESS_EXITED` to the XState actor. Restarting the task doesn't help because `TASK_START` never cleared the stale entry.

## Changes

- **`task-state-manager.ts`**: Added `prepareForRestart(taskId)` method that clears `terminalEventSeen` and `lastSequenceByTask` for a task without stopping the XState actor
- **`execution-handlers.ts`**: Called `prepareForRestart(taskId)` in all 4 locations where a new agent process is started:
  1. `TASK_START` handler - before XState event dispatch
  2. `TASK_STOP` handler - after USER_STOPPED, so subsequent restart works
  3. `TASK_UPDATE_STATUS` auto-start path - when dragging card to in_progress
  4. `TASK_RECOVER_STUCK` auto-restart path - when recovering stuck tasks

Closes #1828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of task restarts, auto-restarts, stops, QA and recovery by proactively clearing stale per-task execution state before re-running tasks.
  * Prevents residual tracking data from previous runs from blocking new processes or causing missed events, enabling cleaner task initialization and more consistent recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->