### PR TITLE
fix: handle empty/greenfield projects in spec creation (#1426)

### DIFF
--- a/apps/backend/prompts/spec_writer.md
+++ b/apps/backend/prompts/spec_writer.md
@@ -24,7 +24,7 @@ You MUST create `spec.md` with ALL required sections (see template below).
 ## PHASE 0: LOAD ALL CONTEXT (MANDATORY)
 
 ```bash
-# Read all input files
+# Read all input files (some may not exist for greenfield/empty projects)
 cat project_index.json
 cat requirements.json
 cat context.json
@@ -34,6 +34,12 @@ Extract from these files:
 - **From project_index.json**: Services, tech stacks, ports, run commands
 - **From requirements.json**: Task description, workflow type, services, acceptance criteria
 - **From context.json**: Files to modify, files to reference, patterns
+
+**IMPORTANT**: If any input file is missing, empty, or shows 0 files, this is likely a **greenfield/new project**. Adapt accordingly:
+- Skip sections that reference existing code (e.g., "Files to Modify", "Patterns to Follow")
+- Instead, focus on files to CREATE and the initial project structure
+- Define the tech stack, dependencies, and setup instructions from scratch
+- Use industry best practices as patterns rather than referencing existing code
 
 ---
 

--- a/apps/backend/spec/phases/spec_phases.py
+++ b/apps/backend/spec/phases/spec_phases.py
@@ -9,10 +9,34 @@ import json
 from typing import TYPE_CHECKING
 
 from .. import validator, writer
+from ..discovery import get_project_index_stats
 from .models import MAX_RETRIES, PhaseResult
 
 if TYPE_CHECKING:
     pass
+
+
+def _is_greenfield_project(spec_dir) -> bool:
+    """Check if the project is empty/greenfield (0 discovered files)."""
+    stats = get_project_index_stats(spec_dir)
+    return stats.get("file_count", 0) == 0
+
+
+def _greenfield_context() -> str:
+    """Return additional context for greenfield/empty projects."""
+    return """
+**GREENFIELD PROJECT**: This is an empty or new project with no existing code.
+There are no existing files to reference or modify. You are creating everything from scratch.
+
+Adapt your approach:
+- Do NOT reference existing files, patterns, or code structures
+- Focus on what needs to be CREATED, not modified
+- Define the initial project structure, files, and directories
+- Specify the tech stack, frameworks, and dependencies to install
+- Provide setup instructions for the new project
+- For "Files to Modify" and "Files to Reference" sections, list files to CREATE instead
+- For "Patterns to Follow", describe industry best practices rather than existing code
+"""
 
 
 class SpecPhaseMixin:
@@ -29,6 +53,13 @@ class SpecPhaseMixin:
                 "quick_spec", True, [str(spec_file), str(plan_file)], [], 0
             )
 
+        is_greenfield = _is_greenfield_project(self.spec_dir)
+        if is_greenfield:
+            self.ui.print_status(
+                "Greenfield project detected - adapting spec for new project",
+                "info",
+            )
+
         errors = []
         for attempt in range(MAX_RETRIES):
             self.ui.print_status(
@@ -42,7 +73,7 @@ class SpecPhaseMixin:
 
 This is a SIMPLE task. Create a minimal spec and implementation plan directly.
 No research or extensive analysis needed.
-
+{_greenfield_context() if is_greenfield else ""}
 Create:
 1. A concise spec.md with just the essential sections
 2. A simple implementation_plan.json with 1-2 subtasks
@@ -80,6 +111,15 @@ Create:
                 "spec.md exists but has issues, regenerating...", "warning"
             )
 
+        is_greenfield = _is_greenfield_project(self.spec_dir)
+        if is_greenfield:
+            self.ui.print_status(
+                "Greenfield project detected - adapting spec for new project",
+                "info",
+            )
+
+        greenfield_ctx = _greenfield_context() if is_greenfield else ""
+
         errors = []
         for attempt in range(MAX_RETRIES):
             self.ui.print_status(
@@ -88,6 +128,7 @@ Create:
 
             success, output = await self.run_agent_fn(
                 "spec_writer.md",
+                additional_context=greenfield_ctx,
                 phase_name="spec_writing",
             )
 

--- a/apps/backend/spec/phases/spec_phases.py
+++ b/apps/backend/spec/phases/spec_phases.py
@@ -7,19 +7,17 @@ Phases for spec document creation and quality assurance.
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from .. import validator, writer
 from ..discovery import get_project_index_stats
 from .models import MAX_RETRIES, PhaseResult
 
-if TYPE_CHECKING:
-    pass
-
 
 def _is_greenfield_project(spec_dir: Path) -> bool:
     """Check if the project is empty/greenfield (0 discovered files)."""
     stats = get_project_index_stats(spec_dir)
+    if not stats:
+        return False  # Can't determine - don't assume greenfield
     return stats.get("file_count", 0) == 0
 
 


### PR DESCRIPTION
## Summary

Fixes spec creation crashing at phase 6 (SPEC DOCUMENT CREATION) for empty/greenfield projects and prevents the planning phase from getting stuck in "active" state after crashes.

Closes #1426

## Root Cause

1. **Phase 6 crash**: The spec writer agent tries to read `project_index.json`, `requirements.json`, and `context.json` which contain no files/code for greenfield projects. The agent gets confused trying to write a spec referencing non-existent code, producing invalid output or timing out. This also affects non-empty projects with sparse context files.

2. **Stuck "active" planning state**: The task logger starts `LogPhase.PLANNING` at orchestrator startup but only calls `end_phase` on specific success/failure code paths. An unexpected exception bypasses all `end_phase` calls, leaving the task permanently stuck in "active" planning status — which contributes to the restart loop behavior.

## Changes

### `apps/backend/spec/phases/spec_phases.py`
- Added `_is_greenfield_project()` — checks `project_index.json` for 0 discovered files
- Added `_greenfield_context()` — returns clear instructions for the agent to focus on creating files from scratch rather than modifying existing code
- Both `phase_quick_spec()` and `phase_spec_writing()` now detect greenfield projects and inject this context into the agent prompt

### `apps/backend/spec/pipeline/orchestrator.py`
- Wrapped phase execution in `try/except` safety net ensuring `task_logger.end_phase()` is always called on unexpected errors
- Extracted phase logic into `_run_phases()` method, with `run()` acting as the safety wrapper
- Prevents tasks from being stuck in "active" planning state after crashes

### `apps/backend/prompts/spec_writer.md`
- Added greenfield awareness to Phase 0 — when input files are missing/empty/show 0 files, adapt to focus on files to CREATE rather than reference existing code

## Test plan

- [x] All 219 spec-related tests pass (spec_phases, spec_pipeline, spec_complexity, implementation_plan)
- [x] Pre-commit hooks pass (ruff lint + format)
- [ ] Manual test: create a spec in an empty directory to verify greenfield detection works
- [ ] Manual test: verify a crashed spec creation properly marks planning phase as failed (not stuck "active")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and tailored guidance for greenfield projects, with explicit PHASE 0 instructions for creating initial structure, tech stack, and patterns when input files are missing.

* **Bug Fixes**
  * Improved orchestration error handling to avoid planning deadlocks and ensure the planning phase concludes on failures.

* **Improvements**
  * Clearer phase lifecycle tracking and unified handling of human-review exits as unapproved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->