### PR TITLE
fix: watch worktree path for implementation_plan.json changes (#1805)

### DIFF
--- a/apps/frontend/src/main/__tests__/file-watcher.test.ts
+++ b/apps/frontend/src/main/__tests__/file-watcher.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for FileWatcher concurrency mechanisms
+ * Tests deduplication, supersession, cancellation, and unwatchAll behaviour
+ * under concurrent watch()/unwatch() call patterns.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// ---------------------------------------------------------------------------
+// Mock chokidar BEFORE importing FileWatcher so the module sees our mock.
+// ---------------------------------------------------------------------------
+
+// A minimal FSWatcher stub that lets us control when close() resolves.
+class MockFSWatcher extends EventEmitter {
+  close: ReturnType<typeof vi.fn>;
+  constructor(closeImpl?: () => Promise<void>) {
+    super();
+    this.close = vi.fn(closeImpl ?? (() => Promise.resolve()));
+  }
+}
+
+// Track every watcher created so tests can inspect them.
+let createdWatchers: MockFSWatcher[] = [];
+// Factory override — tests replace this to inject custom stubs.
+let watchFactory: (() => MockFSWatcher) | null = null;
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn((_path: string, _opts: unknown) => {
+      const watcher = watchFactory ? watchFactory() : new MockFSWatcher();
+      createdWatchers.push(watcher);
+      return watcher;
+    })
+  }
+}));
+
+// Mock 'fs' so we can control existsSync / readFileSync without touching disk.
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(() => JSON.stringify({ phases: [] }))
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are registered
+// ---------------------------------------------------------------------------
+import { FileWatcher } from '../file-watcher';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FileWatcher concurrency', () => {
+  let fw: FileWatcher;
+
+  beforeEach(() => {
+    fw = new FileWatcher();
+    createdWatchers = [];
+    watchFactory = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Clean up any watchers that are still open.
+    await fw.unwatchAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Deduplication — same taskId + same specDir
+  // -------------------------------------------------------------------------
+  describe('deduplication: second watch() with same specDir is a no-op', () => {
+    it('should only create one FSWatcher when watch() is called twice with the same specDir while the first is still in-flight', async () => {
+      const specDir = '/project/.auto-claude/specs/001-task';
+      const taskId = 'task-1';
+
+      // To create a real async gap we need an existing watcher whose close() is slow.
+      // First, set up a watcher for taskId (completes synchronously).
+      await fw.watch(taskId, specDir);
+      expect(createdWatchers).toHaveLength(1);
+
+      // Replace close() with a slow one so the next watch() call has an async gap.
+      const existingWatcher = createdWatchers[0];
+      let resolveClose!: () => void;
+      existingWatcher.close = vi.fn(
+        () => new Promise<void>((res) => { resolveClose = res; })
+      );
+
+      // Now start two concurrent watch() calls for the SAME specDir.
+      // Both will try to enter, but the second should be deduplicated.
+      const watchPromise1 = fw.watch(taskId, specDir);
+      const watchPromise2 = fw.watch(taskId, specDir);
+
+      // Resolve the close so both can proceed.
+      resolveClose();
+      await Promise.all([watchPromise1, watchPromise2]);
+
+      // Only one new FSWatcher should have been created (the second call was a no-op).
+      // createdWatchers[0] is the original; createdWatchers[1] is the new one.
+      expect(createdWatchers).toHaveLength(2);
+      expect(fw.isWatching(taskId)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Supersession — same taskId, different specDir
+  // -------------------------------------------------------------------------
+  describe('supersession: watch() with different specDir replaces the in-flight call', () => {
+    it('should let the second call win when the first is awaiting close()', async () => {
+      const taskId = 'task-2';
+      const specDir1 = '/project/.auto-claude/specs/001-first';
+      const specDir2 = '/project/.auto-claude/specs/002-second';
+
+      // First call installs an existing watcher (simulate: the watcher for
+      // specDir1 is already set up so the second watch() needs to close it).
+      // We do this by running the first watch() to completion first.
+      await fw.watch(taskId, specDir1);
+      expect(createdWatchers).toHaveLength(1);
+
+      // Now make the close() of the first watcher slow so there's an async gap
+      // during which the second watch() can enter and supersede.
+      const existingWatcher = createdWatchers[0];
+      let resolveClose!: () => void;
+      existingWatcher.close = vi.fn(
+        () => new Promise<void>((res) => { resolveClose = res; })
+      );
+
+      // Start the second watch() — it will try to close the first watcher's
+      // FSWatcher and will be awaiting that.
+      const watch2Promise = fw.watch(taskId, specDir2);
+
+      // While the second watch() is awaiting close, start a THIRD call with
+      // yet another specDir — this supersedes the second call.
+      // Actually for the test described in the finding, we want:
+      // - First call bails, second call creates the watcher.
+      // Let's resolve the close and let watch2 finish.
+      resolveClose();
+      await watch2Promise;
+
+      // The final watcher should be for specDir2.
+      expect(fw.getWatchedSpecDir(taskId)).toBe(specDir2);
+      // Two watchers were created in total (one for each specDir).
+      expect(createdWatchers).toHaveLength(2);
+    });
+
+    it('first watch() bails when pendingWatches changes to a different specDir', async () => {
+      const taskId = 'task-super';
+      const specDir1 = '/project/.auto-claude/specs/super-first';
+      const specDir2 = '/project/.auto-claude/specs/super-second';
+
+      // Make the first watcher's close() slow so we can interleave.
+      let resolveFirstClose!: () => void;
+      watchFactory = () => {
+        const w = new MockFSWatcher(() => new Promise<void>((res) => { resolveFirstClose = res; }));
+        return w;
+      };
+
+      // Start first watch().
+      const watch1Promise = fw.watch(taskId, specDir1);
+
+      // Immediately start second watch() — before the first has resolved the
+      // slow close(). At this point specDir1 watch hasn't even created an
+      // FSWatcher yet (it's the very first call so there's no existing watcher
+      // to close), so watch1Promise may resolve synchronously up to watcher
+      // creation. Reset factory to normal for subsequent watcher creations.
+      watchFactory = null;
+
+      const watch2Promise = fw.watch(taskId, specDir2);
+
+      // Let any remaining microtasks run.
+      await Promise.resolve();
+      if (resolveFirstClose) resolveFirstClose();
+
+      await Promise.all([watch1Promise, watch2Promise]);
+
+      // The winning call (specDir2) should own the watcher.
+      expect(fw.getWatchedSpecDir(taskId)).toBe(specDir2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Cancellation — unwatch() during in-flight watch()
+  // -------------------------------------------------------------------------
+  describe('cancellation: unwatch() during in-flight watch() prevents watcher creation', () => {
+    it('should not create a watcher when unwatch() is called before the async gap resolves', async () => {
+      const taskId = 'task-3';
+      const specDir = '/project/.auto-claude/specs/003-cancel';
+
+      // There's no pre-existing watcher, so watch() won't call close(). But it
+      // does go async (chokidar.watch is sync but we can test the cancellation
+      // flag by calling unwatch() before watch() runs).
+      // The real async gap in watch() is the existing.watcher.close() call.
+      // For this test, let's pre-install a watcher so close() is called.
+
+      // Install a slow-close watcher for taskId by manually populating the map.
+      // We can do that by running a first watch(), then replacing close().
+      await fw.watch(taskId, specDir);
+
+      // Replace the watcher's close() with a slow one.
+      const existingWatcher = createdWatchers[0];
+      let resolveExistingClose!: () => void;
+      existingWatcher.close = vi.fn(
+        () => new Promise<void>((res) => { resolveExistingClose = res; })
+      );
+
+      // Start a second watch() — it will await the slow close().
+      const specDir2 = '/project/.auto-claude/specs/003-cancel-v2';
+      const watchPromise = fw.watch(taskId, specDir2);
+
+      // While watch() is in-flight, call unwatch().
+      await fw.unwatch(taskId);
+
+      // Now resolve the slow close so watch() can continue past the await.
+      resolveExistingClose();
+      await watchPromise;
+
+      // No new watcher should have been registered.
+      expect(fw.isWatching(taskId)).toBe(false);
+      // Only one FSWatcher was ever created (the original one for specDir).
+      expect(createdWatchers).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. unwatchAll() with pending watches
+  // -------------------------------------------------------------------------
+  describe('unwatchAll() cancels all pending watches', () => {
+    it('should cancel pending watch() calls and clear pendingWatches', async () => {
+      const taskId1 = 'task-4a';
+      const taskId2 = 'task-4b';
+      const specDir1 = '/project/.auto-claude/specs/004a';
+      const specDir2 = '/project/.auto-claude/specs/004b';
+
+      // Set up slow-close scenario for taskId1 (so watch() is in-flight).
+      await fw.watch(taskId1, specDir1);
+      const watcher1 = createdWatchers[0];
+      let resolveClose1!: () => void;
+      watcher1.close = vi.fn(
+        () => new Promise<void>((res) => { resolveClose1 = res; })
+      );
+
+      // Start a new watch for taskId1 with a different specDir — this is now in-flight.
+      const newSpecDir1 = '/project/.auto-claude/specs/004a-v2';
+      const watchPromise1 = fw.watch(taskId1, newSpecDir1);
+
+      // Start a fresh watch for taskId2.
+      await fw.watch(taskId2, specDir2);
+
+      // Call unwatchAll() while watchPromise1 is still pending.
+      const unwatchAllPromise = fw.unwatchAll();
+
+      // Resolve the slow close so everything can proceed.
+      resolveClose1();
+      await Promise.all([watchPromise1, unwatchAllPromise]);
+
+      // After unwatchAll, no watchers should be active.
+      expect(fw.isWatching(taskId1)).toBe(false);
+      expect(fw.isWatching(taskId2)).toBe(false);
+
+      // pendingWatches should be cleared (we verify indirectly: a fresh
+      // watch() call for taskId1 must succeed without treating it as a duplicate).
+      const specDirFresh = '/project/.auto-claude/specs/004a-fresh';
+      await fw.watch(taskId1, specDirFresh);
+      expect(fw.isWatching(taskId1)).toBe(true);
+      expect(fw.getWatchedSpecDir(taskId1)).toBe(specDirFresh);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. getWatchedSpecDir() returns correct specDir
+  // -------------------------------------------------------------------------
+  describe('getWatchedSpecDir()', () => {
+    it('returns the specDir that was passed to watch()', async () => {
+      const taskId = 'task-5';
+      const specDir = '/project/.auto-claude/specs/005-specdir';
+
+      await fw.watch(taskId, specDir);
+
+      expect(fw.getWatchedSpecDir(taskId)).toBe(specDir);
+    });
+
+    it('returns null when the task is not being watched', () => {
+      expect(fw.getWatchedSpecDir('unknown-task')).toBeNull();
+    });
+
+    it('returns updated specDir after re-watch with different specDir', async () => {
+      const taskId = 'task-5b';
+      const specDir1 = '/project/.auto-claude/specs/005b-first';
+      const specDir2 = '/project/.auto-claude/specs/005b-second';
+
+      await fw.watch(taskId, specDir1);
+      expect(fw.getWatchedSpecDir(taskId)).toBe(specDir1);
+
+      await fw.watch(taskId, specDir2);
+      expect(fw.getWatchedSpecDir(taskId)).toBe(specDir2);
+    });
+  });
+});

--- a/apps/frontend/src/main/__tests__/file-watcher.test.ts
+++ b/apps/frontend/src/main/__tests__/file-watcher.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
+import path from 'path';
 
 // ---------------------------------------------------------------------------
 // Mock chokidar BEFORE importing FileWatcher so the module sees our mock.
@@ -110,8 +111,8 @@ describe('FileWatcher concurrency', () => {
   describe('supersession: watch() with different specDir replaces the in-flight call', () => {
     it('should let the second call win when the first is awaiting close()', async () => {
       const taskId = 'task-2';
-      const specDir1 = '/project/.auto-claude/specs/001-first';
-      const specDir2 = '/project/.auto-claude/specs/002-second';
+      const specDir1 = path.join('/project', '.auto-claude', 'specs', '001-first');
+      const specDir2 = path.join('/project', '.auto-claude', 'specs', '002-second');
 
       // First call installs an existing watcher (simulate: the watcher for
       // specDir1 is already set up so the second watch() needs to close it).
@@ -147,8 +148,8 @@ describe('FileWatcher concurrency', () => {
 
     it('first watch() bails when pendingWatches changes to a different specDir', async () => {
       const taskId = 'task-super';
-      const specDir1 = '/project/.auto-claude/specs/super-first';
-      const specDir2 = '/project/.auto-claude/specs/super-second';
+      const specDir1 = path.join('/project', '.auto-claude', 'specs', 'super-first');
+      const specDir2 = path.join('/project', '.auto-claude', 'specs', 'super-second');
 
       // Make the first watcher's close() slow so we can interleave.
       let resolveFirstClose!: () => void;
@@ -261,7 +262,7 @@ describe('FileWatcher concurrency', () => {
 
       // pendingWatches should be cleared (we verify indirectly: a fresh
       // watch() call for taskId1 must succeed without treating it as a duplicate).
-      const specDirFresh = '/project/.auto-claude/specs/004a-fresh';
+      const specDirFresh = path.join('/project', '.auto-claude', 'specs', '004a-fresh');
       await fw.watch(taskId1, specDirFresh);
       expect(fw.isWatching(taskId1)).toBe(true);
       expect(fw.getWatchedSpecDir(taskId1)).toBe(specDirFresh);
@@ -274,7 +275,7 @@ describe('FileWatcher concurrency', () => {
   describe('getWatchedSpecDir()', () => {
     it('returns the specDir that was passed to watch()', async () => {
       const taskId = 'task-5';
-      const specDir = '/project/.auto-claude/specs/005-specdir';
+      const specDir = path.join('/project', '.auto-claude', 'specs', '005-specdir');
 
       await fw.watch(taskId, specDir);
 
@@ -287,8 +288,8 @@ describe('FileWatcher concurrency', () => {
 
     it('returns updated specDir after re-watch with different specDir', async () => {
       const taskId = 'task-5b';
-      const specDir1 = '/project/.auto-claude/specs/005b-first';
-      const specDir2 = '/project/.auto-claude/specs/005b-second';
+      const specDir1 = path.join('/project', '.auto-claude', 'specs', '005b-first');
+      const specDir2 = path.join('/project', '.auto-claude', 'specs', '005b-second');
 
       await fw.watch(taskId, specDir1);
       expect(fw.getWatchedSpecDir(taskId)).toBe(specDir1);

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -108,6 +108,15 @@ export class FileWatcher extends EventEmitter {
   }
 
   /**
+   * Get the spec directory currently being watched for a task
+   */
+  getWatchedSpecDir(taskId: string): string | null {
+    const watcherInfo = this.watchers.get(taskId);
+    if (!watcherInfo) return null;
+    return path.dirname(watcherInfo.planPath);
+  }
+
+  /**
    * Get current plan state for a task
    */
   getCurrentPlan(taskId: string): ImplementationPlan | null {

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -45,6 +45,13 @@ export class FileWatcher extends EventEmitter {
         this.watchers.delete(taskId);
       }
 
+      // Check if a newer watch() call has superseded this one while we were awaiting.
+      // If the pending specDir changed, another concurrent watch() took over — bail out
+      // to avoid overwriting the watcher it is about to create.
+      if (this.pendingWatches.get(taskId) !== specDir) {
+        return;
+      }
+
       // Check if unwatch() was called while we were awaiting above.
       if (this.cancelledWatches.has(taskId)) {
         this.cancelledWatches.delete(taskId);
@@ -119,10 +126,12 @@ export class FileWatcher extends EventEmitter {
    * Stop watching a task
    */
   async unwatch(taskId: string): Promise<void> {
-    // If watch() is currently in-flight for this taskId, mark it as cancelled
-    // so it returns early after its next await instead of creating a new watcher.
+    // If watch() is currently in-flight for this taskId, it is already closing the
+    // existing watcher. Just set the cancellation flag and return to avoid a
+    // double-close of the same FSWatcher.
     if (this.pendingWatches.has(taskId)) {
       this.cancelledWatches.add(taskId);
+      return;
     }
     const watcherInfo = this.watchers.get(taskId);
     if (watcherInfo) {
@@ -135,6 +144,11 @@ export class FileWatcher extends EventEmitter {
    * Stop all watchers
    */
   async unwatchAll(): Promise<void> {
+    // Cancel any in-flight watch() calls so they don't create new watchers
+    // after this cleanup completes.
+    for (const taskId of this.pendingWatches.keys()) {
+      this.cancelledWatches.add(taskId);
+    }
     const closePromises = Array.from(this.watchers.values()).map(
       async (info) => {
         await info.watcher.close();

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -126,12 +126,10 @@ export class FileWatcher extends EventEmitter {
       // can proceed correctly.
       if (this.pendingWatches.get(taskId) === specDir) {
         this.pendingWatches.delete(taskId);
-        // Only clear the cancellation flag when there is no longer any
-        // in-flight watch() for this taskId. If unwatch() set the flag
-        // for the superseding call, that call still needs to see it.
-        if (!this.pendingWatches.has(taskId)) {
-          this.cancelledWatches.delete(taskId);
-        }
+        // The delete above guarantees has() is now false, so there is no
+        // longer any in-flight watch() for this taskId. Clear the
+        // cancellation flag so it doesn't linger for future watch() calls.
+        this.cancelledWatches.delete(taskId);
       }
     }
   }
@@ -163,6 +161,12 @@ export class FileWatcher extends EventEmitter {
     for (const taskId of this.pendingWatches.keys()) {
       this.cancelledWatches.add(taskId);
     }
+    this.pendingWatches.clear();
+    // Clear cancellation flags now that pendingWatches is empty: the in-flight
+    // calls will bail via the supersession check (pendingWatches.get() returns
+    // undefined) and will not clean up cancelledWatches themselves. Clearing
+    // here ensures the instance is fully reset for subsequent use.
+    this.cancelledWatches.clear();
     const closePromises = Array.from(this.watchers.values()).map(
       async (info) => {
         await info.watcher.close();

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -15,64 +15,81 @@ interface WatcherInfo {
  */
 export class FileWatcher extends EventEmitter {
   private watchers: Map<string, WatcherInfo> = new Map();
+  private pendingWatches: Set<string> = new Set();
 
   /**
    * Start watching a task's implementation plan
    */
   async watch(taskId: string, specDir: string): Promise<void> {
-    // Stop any existing watcher for this task
-    await this.unwatch(taskId);
-
-    const planPath = path.join(specDir, 'implementation_plan.json');
-
-    // Check if plan file exists
-    if (!existsSync(planPath)) {
-      this.emit('error', taskId, `Plan file not found: ${planPath}`);
+    // Prevent overlapping watch() calls for the same taskId.
+    // Since watch() is async, rapid-fire callers could enter concurrently
+    // before the first call updates state, creating duplicate watchers.
+    if (this.pendingWatches.has(taskId)) {
       return;
     }
+    this.pendingWatches.add(taskId);
 
-    // Create watcher with settings to handle frequent writes
-    const watcher = chokidar.watch(planPath, {
-      persistent: true,
-      ignoreInitial: true,
-      awaitWriteFinish: {
-        stabilityThreshold: 300,
-        pollInterval: 100
+    try {
+      // Close any existing watcher for this task
+      const existing = this.watchers.get(taskId);
+      if (existing) {
+        await existing.watcher.close();
+        this.watchers.delete(taskId);
       }
-    });
 
-    // Store watcher info
-    this.watchers.set(taskId, {
-      taskId,
-      watcher,
-      planPath
-    });
+      const planPath = path.join(specDir, 'implementation_plan.json');
 
-    // Handle file changes
-    watcher.on('change', () => {
+      // Check if plan file exists
+      if (!existsSync(planPath)) {
+        this.emit('error', taskId, `Plan file not found: ${planPath}`);
+        return;
+      }
+
+      // Create watcher with settings to handle frequent writes
+      const watcher = chokidar.watch(planPath, {
+        persistent: true,
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 300,
+          pollInterval: 100
+        }
+      });
+
+      // Store watcher info
+      this.watchers.set(taskId, {
+        taskId,
+        watcher,
+        planPath
+      });
+
+      // Handle file changes
+      watcher.on('change', () => {
+        try {
+          const content = readFileSync(planPath, 'utf-8');
+          const plan: ImplementationPlan = JSON.parse(content);
+          this.emit('progress', taskId, plan);
+        } catch {
+          // File might be in the middle of being written
+          // Ignore parse errors, next change event will have complete file
+        }
+      });
+
+      // Handle errors
+      watcher.on('error', (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.emit('error', taskId, message);
+      });
+
+      // Read and emit initial state
       try {
         const content = readFileSync(planPath, 'utf-8');
         const plan: ImplementationPlan = JSON.parse(content);
         this.emit('progress', taskId, plan);
       } catch {
-        // File might be in the middle of being written
-        // Ignore parse errors, next change event will have complete file
+        // Initial read failed - not critical
       }
-    });
-
-    // Handle errors
-    watcher.on('error', (error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      this.emit('error', taskId, message);
-    });
-
-    // Read and emit initial state
-    try {
-      const content = readFileSync(planPath, 'utf-8');
-      const plan: ImplementationPlan = JSON.parse(content);
-      this.emit('progress', taskId, plan);
-    } catch {
-      // Initial read failed - not critical
+    } finally {
+      this.pendingWatches.delete(taskId);
     }
   }
 

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -15,19 +15,27 @@ interface WatcherInfo {
  */
 export class FileWatcher extends EventEmitter {
   private watchers: Map<string, WatcherInfo> = new Map();
-  private pendingWatches: Set<string> = new Set();
+  // Maps taskId -> specDir for the in-flight watch() call.
+  // Allows re-watch calls with a different specDir to proceed while
+  // still preventing duplicate calls for the exact same specDir.
+  private pendingWatches: Map<string, string> = new Map();
+  // Tracks taskIds that had unwatch() called while watch() was in-flight.
+  // Checked after each await point in watch() to avoid creating a leaked watcher.
+  private cancelledWatches: Set<string> = new Set();
 
   /**
    * Start watching a task's implementation plan
    */
   async watch(taskId: string, specDir: string): Promise<void> {
-    // Prevent overlapping watch() calls for the same taskId.
+    // Prevent overlapping watch() calls for the same taskId + specDir combination.
     // Since watch() is async, rapid-fire callers could enter concurrently
     // before the first call updates state, creating duplicate watchers.
-    if (this.pendingWatches.has(taskId)) {
+    // A call with a different specDir is a legitimate re-watch and is allowed through.
+    const pendingSpecDir = this.pendingWatches.get(taskId);
+    if (pendingSpecDir !== undefined && pendingSpecDir === specDir) {
       return;
     }
-    this.pendingWatches.add(taskId);
+    this.pendingWatches.set(taskId, specDir);
 
     try {
       // Close any existing watcher for this task
@@ -35,6 +43,12 @@ export class FileWatcher extends EventEmitter {
       if (existing) {
         await existing.watcher.close();
         this.watchers.delete(taskId);
+      }
+
+      // Check if unwatch() was called while we were awaiting above.
+      if (this.cancelledWatches.has(taskId)) {
+        this.cancelledWatches.delete(taskId);
+        return;
       }
 
       const planPath = path.join(specDir, 'implementation_plan.json');
@@ -54,6 +68,13 @@ export class FileWatcher extends EventEmitter {
           pollInterval: 100
         }
       });
+
+      // Check again after the synchronous watcher creation (no await, but defensive).
+      if (this.cancelledWatches.has(taskId)) {
+        this.cancelledWatches.delete(taskId);
+        await watcher.close();
+        return;
+      }
 
       // Store watcher info
       this.watchers.set(taskId, {
@@ -90,6 +111,7 @@ export class FileWatcher extends EventEmitter {
       }
     } finally {
       this.pendingWatches.delete(taskId);
+      this.cancelledWatches.delete(taskId);
     }
   }
 
@@ -97,6 +119,11 @@ export class FileWatcher extends EventEmitter {
    * Stop watching a task
    */
   async unwatch(taskId: string): Promise<void> {
+    // If watch() is currently in-flight for this taskId, mark it as cancelled
+    // so it returns early after its next await instead of creating a new watcher.
+    if (this.pendingWatches.has(taskId)) {
+      this.cancelledWatches.add(taskId);
+    }
     const watcherInfo = this.watchers.get(taskId);
     if (watcherInfo) {
       await watcherInfo.watcher.close();

--- a/apps/frontend/src/main/file-watcher.ts
+++ b/apps/frontend/src/main/file-watcher.ts
@@ -38,11 +38,14 @@ export class FileWatcher extends EventEmitter {
     this.pendingWatches.set(taskId, specDir);
 
     try {
-      // Close any existing watcher for this task
+      // Close any existing watcher for this task.
+      // Delete from the map BEFORE awaiting close so that a concurrent watch()
+      // call entering after the await cannot obtain the same FSWatcher reference
+      // and attempt a second close() on the same object.
       const existing = this.watchers.get(taskId);
       if (existing) {
-        await existing.watcher.close();
         this.watchers.delete(taskId);
+        await existing.watcher.close();
       }
 
       // Check if a newer watch() call has superseded this one while we were awaiting.
@@ -117,8 +120,19 @@ export class FileWatcher extends EventEmitter {
         // Initial read failed - not critical
       }
     } finally {
-      this.pendingWatches.delete(taskId);
-      this.cancelledWatches.delete(taskId);
+      // Only clean up if this call still owns the entry. If a superseding
+      // concurrent watch() call has already updated pendingWatches with a
+      // different specDir, leave that entry intact so the superseding call
+      // can proceed correctly.
+      if (this.pendingWatches.get(taskId) === specDir) {
+        this.pendingWatches.delete(taskId);
+        // Only clear the cancellation flag when there is no longer any
+        // in-flight watch() for this taskId. If unwatch() set the flag
+        // for the superseding call, that call still needs to see it.
+        if (!this.pendingWatches.has(taskId)) {
+          this.cancelledWatches.delete(taskId);
+        }
+      }
     }
   }
 

--- a/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
@@ -243,7 +243,9 @@ export function registerAgenteventsHandlers(
         const currentWatchDir = fileWatcher.getWatchedSpecDir(taskId);
         if (currentWatchDir && currentWatchDir !== worktreeSpecDir && existsSync(worktreePlanPath)) {
           console.warn(`[agent-events-handlers] Re-watching worktree path for ${taskId}: ${worktreeSpecDir}`);
-          fileWatcher.watch(taskId, worktreeSpecDir);
+          fileWatcher.watch(taskId, worktreeSpecDir).catch((err) => {
+            console.error(`[agent-events-handlers] Failed to re-watch worktree for ${taskId}:`, err);
+          });
         }
       }
     } else if (xstateInTerminalState && progress.phase) {

--- a/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/agent-events-handlers.ts
@@ -125,7 +125,9 @@ export function registerAgenteventsHandlers(
       );
     }
 
-    fileWatcher.unwatch(taskId);
+    fileWatcher.unwatch(taskId).catch((err) => {
+      console.error(`[agent-events-handlers] Failed to unwatch for ${taskId}:`, err);
+    });
 
     if (processType === "spec-creation") {
       console.warn(`[Task ${taskId}] Spec creation completed with code ${code}`);

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -89,7 +89,10 @@ async function ensureProfileManagerInitialized(): Promise<
 function getSpecDirForWatcher(projectPath: string, specsBaseDir: string, specId: string): string {
   const worktreePath = findTaskWorktree(projectPath, specId);
   if (worktreePath) {
-    return path.join(worktreePath, specsBaseDir, specId);
+    const worktreeSpecDir = path.join(worktreePath, specsBaseDir, specId);
+    if (existsSync(path.join(worktreeSpecDir, 'implementation_plan.json'))) {
+      return worktreeSpecDir;
+    }
   }
   return path.join(projectPath, specsBaseDir, specId);
 }

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -82,6 +82,19 @@ async function ensureProfileManagerInitialized(): Promise<
 }
 
 /**
+ * Get the spec directory for file watching, preferring the worktree path if it exists.
+ * When a task runs in a worktree, implementation_plan.json is written there,
+ * not in the main project's spec directory.
+ */
+function getSpecDirForWatcher(projectPath: string, specsBaseDir: string, specId: string): string {
+  const worktreePath = findTaskWorktree(projectPath, specId);
+  if (worktreePath) {
+    return path.join(worktreePath, specsBaseDir, specId);
+  }
+  return path.join(projectPath, specsBaseDir, specId);
+}
+
+/**
  * Register task execution handlers (start, stop, review, status management, recovery)
  */
 export function registerTaskExecutionHandlers(
@@ -234,10 +247,14 @@ export function registerTaskExecutionHandlers(
         console.warn(`[TASK_START] Reset ${resetResult.resetCount} stuck subtask(s) before starting`);
       }
 
-      // Start file watcher for this task (specsBaseDir and specDir already computed above)
-      fileWatcher.watch(taskId, specDir);
+      // Start file watcher for this task
+      // Use worktree path if it exists, since the backend writes implementation_plan.json there
+      const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
+      fileWatcher.watch(taskId, watchSpecDir);
 
       // Check if spec.md exists (indicates spec creation was already done or in progress)
+      // Check main project path for spec file (spec is created before worktree)
+      const specDir = path.join(project.path, specsBaseDir, task.specId);
       const specFilePath = path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE);
       const hasSpec = existsSync(specFilePath);
 
@@ -732,7 +749,9 @@ export function registerTaskExecutionHandlers(
           }
 
           // Start file watcher for this task
-          fileWatcher.watch(taskId, specDir);
+          // Use worktree path if it exists, since the backend writes implementation_plan.json there
+          const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
+          fileWatcher.watch(taskId, watchSpecDir);
 
           // Check if spec.md exists
           const specFilePath = path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE);
@@ -1180,12 +1199,15 @@ export function registerTaskExecutionHandlers(
 
             // Start the task execution
             // Start file watcher for this task
-            const specsBaseDir = getSpecsDir(project.autoBuildPath);
-            const specDirForWatcher = path.join(project.path, specsBaseDir, task.specId);
+            // Use worktree path if it exists, since the backend writes implementation_plan.json there
+            const specsBaseDirForRecovery = getSpecsDir(project.autoBuildPath);
+            const specDirForWatcher = getSpecDirForWatcher(project.path, specsBaseDirForRecovery, task.specId);
             fileWatcher.watch(taskId, specDirForWatcher);
 
             // Check if spec.md exists to determine whether to run spec creation or task execution
-            const specFilePath = path.join(specDirForWatcher, AUTO_BUILD_PATHS.SPEC_FILE);
+            // Check main project path for spec file (spec is created before worktree)
+            const mainSpecDirForRecovery = path.join(project.path, specsBaseDirForRecovery, task.specId);
+            const specFilePath = path.join(mainSpecDirForRecovery, AUTO_BUILD_PATHS.SPEC_FILE);
             const hasSpec = existsSync(specFilePath);
             const needsSpecCreation = !hasSpec;
 
@@ -1196,7 +1218,7 @@ export function registerTaskExecutionHandlers(
               // No spec file - need to run spec_runner.py to create the spec
               const taskDescription = task.description || task.title;
               console.warn(`[Recovery] Starting spec creation for: ${task.specId}`);
-              agentManager.startSpecCreation(taskId, project.path, taskDescription, specDirForWatcher, task.metadata, baseBranchForRecovery, project.id);
+              agentManager.startSpecCreation(taskId, project.path, taskDescription, mainSpecDirForRecovery, task.metadata, baseBranchForRecovery, project.id);
             } else {
               // Spec exists - run task execution
               console.warn(`[Recovery] Starting task execution for: ${task.specId}`);

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -330,7 +330,9 @@ export function registerTaskExecutionHandlers(
    */
   ipcMain.on(IPC_CHANNELS.TASK_STOP, (_, taskId: string) => {
     agentManager.killTask(taskId);
-    fileWatcher.unwatch(taskId);
+    fileWatcher.unwatch(taskId).catch((err) => {
+      console.error('[TASK_STOP] Failed to unwatch:', err);
+    });
 
     // Find task and project to emit USER_STOPPED with plan context
     const { task, project } = findTaskAndProject(taskId);
@@ -1122,7 +1124,9 @@ export function registerTaskExecutionHandlers(
         }
 
         // Stop file watcher if it was watching this task
-        fileWatcher.unwatch(taskId);
+        fileWatcher.unwatch(taskId).catch((err) => {
+          console.error('[TASK_RECOVER_STUCK] Failed to unwatch:', err);
+        });
 
         // Auto-restart the task if requested
         let autoRestarted = false;

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -250,7 +250,9 @@ export function registerTaskExecutionHandlers(
       // Start file watcher for this task
       // Use worktree path if it exists, since the backend writes implementation_plan.json there
       const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
-      fileWatcher.watch(taskId, watchSpecDir);
+      fileWatcher.watch(taskId, watchSpecDir).catch((err) => {
+        console.error(`[TASK_START] Failed to watch spec dir for ${taskId}:`, err);
+      });
 
       // Check if spec.md exists (indicates spec creation was already done or in progress)
       // Check main project path for spec file (spec is created before worktree)
@@ -751,7 +753,9 @@ export function registerTaskExecutionHandlers(
           // Start file watcher for this task
           // Use worktree path if it exists, since the backend writes implementation_plan.json there
           const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
-          fileWatcher.watch(taskId, watchSpecDir);
+          fileWatcher.watch(taskId, watchSpecDir).catch((err) => {
+            console.error(`[TASK_UPDATE_STATUS] Failed to watch spec dir for ${taskId}:`, err);
+          });
 
           // Check if spec.md exists
           const specFilePath = path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE);
@@ -1200,9 +1204,10 @@ export function registerTaskExecutionHandlers(
             // Start the task execution
             // Start file watcher for this task
             // Use worktree path if it exists, since the backend writes implementation_plan.json there
-            const specsBaseDir = getSpecsDir(project.autoBuildPath);
             const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
-            fileWatcher.watch(taskId, watchSpecDir);
+            fileWatcher.watch(taskId, watchSpecDir).catch((err) => {
+              console.error(`[Recovery] Failed to watch spec dir for ${taskId}:`, err);
+            });
 
             // Check if spec.md exists to determine whether to run spec creation or task execution
             // Check main project path for spec file (spec is created before worktree)

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1215,7 +1215,7 @@ export function registerTaskExecutionHandlers(
 
             // Check if spec.md exists to determine whether to run spec creation or task execution
             // Check main project path for spec file (spec is created before worktree)
-            // mainSpecDir is declared in the outer try block above
+            // mainSpecDir is declared earlier in the handler scope
             const specFilePath = path.join(mainSpecDir, AUTO_BUILD_PATHS.SPEC_FILE);
             const hasSpec = existsSync(specFilePath);
             const needsSpecCreation = !hasSpec;

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1200,14 +1200,14 @@ export function registerTaskExecutionHandlers(
             // Start the task execution
             // Start file watcher for this task
             // Use worktree path if it exists, since the backend writes implementation_plan.json there
-            const specsBaseDirForRecovery = getSpecsDir(project.autoBuildPath);
-            const specDirForWatcher = getSpecDirForWatcher(project.path, specsBaseDirForRecovery, task.specId);
-            fileWatcher.watch(taskId, specDirForWatcher);
+            const specsBaseDir = getSpecsDir(project.autoBuildPath);
+            const watchSpecDir = getSpecDirForWatcher(project.path, specsBaseDir, task.specId);
+            fileWatcher.watch(taskId, watchSpecDir);
 
             // Check if spec.md exists to determine whether to run spec creation or task execution
             // Check main project path for spec file (spec is created before worktree)
-            const mainSpecDirForRecovery = path.join(project.path, specsBaseDirForRecovery, task.specId);
-            const specFilePath = path.join(mainSpecDirForRecovery, AUTO_BUILD_PATHS.SPEC_FILE);
+            const mainSpecDir = path.join(project.path, specsBaseDir, task.specId);
+            const specFilePath = path.join(mainSpecDir, AUTO_BUILD_PATHS.SPEC_FILE);
             const hasSpec = existsSync(specFilePath);
             const needsSpecCreation = !hasSpec;
 
@@ -1218,7 +1218,7 @@ export function registerTaskExecutionHandlers(
               // No spec file - need to run spec_runner.py to create the spec
               const taskDescription = task.description || task.title;
               console.warn(`[Recovery] Starting spec creation for: ${task.specId}`);
-              agentManager.startSpecCreation(taskId, project.path, taskDescription, mainSpecDirForRecovery, task.metadata, baseBranchForRecovery, project.id);
+              agentManager.startSpecCreation(taskId, project.path, taskDescription, mainSpecDir, task.metadata, baseBranchForRecovery, project.id);
             } else {
               // Spec exists - run task execution
               console.warn(`[Recovery] Starting task execution for: ${task.specId}`);

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -259,7 +259,6 @@ export function registerTaskExecutionHandlers(
 
       // Check if spec.md exists (indicates spec creation was already done or in progress)
       // Check main project path for spec file (spec is created before worktree)
-      const specDir = path.join(project.path, specsBaseDir, task.specId);
       const specFilePath = path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE);
       const hasSpec = existsSync(specFilePath);
 

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1211,7 +1211,7 @@ export function registerTaskExecutionHandlers(
 
             // Check if spec.md exists to determine whether to run spec creation or task execution
             // Check main project path for spec file (spec is created before worktree)
-            const mainSpecDir = path.join(project.path, specsBaseDir, task.specId);
+            // mainSpecDir is declared in the outer try block above
             const specFilePath = path.join(mainSpecDir, AUTO_BUILD_PATHS.SPEC_FILE);
             const hasSpec = existsSync(specFilePath);
             const needsSpecCreation = !hasSpec;


### PR DESCRIPTION
## Summary

Fixes #1805 - Subtasks not generated/updated correctly since v2.7.6-beta.3

### Root Cause

The `FileWatcher` was always watching the **main project's** spec directory for `implementation_plan.json` changes. When tasks run in a worktree (the default since v2.7.6-beta.3), the backend writes the plan file to the **worktree's** spec directory instead. The `FileWatcher` never detected changes, so `TASK_PROGRESS` IPC events were never sent to the renderer, resulting in "0 subtasks" in the UI.

### Changes

- **`file-watcher.ts`**: Added `getWatchedSpecDir()` method to check what path is currently being watched
- **`execution-handlers.ts`**: Added `getSpecDirForWatcher()` helper that checks worktree path first, falls back to main project path. Updated all 3 file watcher setup locations:
  1. `TASK_START` handler
  2. `TASK_UPDATE_STATUS` auto-start
  3. `TASK_RECOVER_STUCK` auto-restart
- **`agent-events-handlers.ts`**: 
  - Added re-watch logic in `execution-progress` handler: when a worktree appears after task start (task started before worktree was created), automatically switches the watcher to the worktree path
  - Added worktree fallback in `exit` handler for reading final plan state when the watcher was on the wrong path

### Edge Cases Handled

- **Worktree exists at task start**: Watches worktree path directly
- **Worktree created after task start**: Re-watch logic in execution-progress handler switches to worktree when it appears
- **Worktree deleted after completion**: Exit handler cleanly unwatches; chokidar handles missing files gracefully
- **Non-worktree tasks**: Falls back to main project path (behavior unchanged)

Closes #1805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query which spec directory a watcher is observing.
  * Watchers emit an initial progress update when established.
  * Watchers can switch to a worktree spec directory when appropriate.

* **Bug Fixes**
  * Better final-plan recovery using watcher and worktree fallbacks.
  * Prevent overlapping/in-flight watcher operations and avoid watcher leaks on cancellation.
  * Ensure progress persistence and watcher paths correctly handle worktree scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->