### PR TITLE
fix(profiles): use unified account selection in terminal rate limit handler

### DIFF
--- a/apps/frontend/src/main/claude-profile/__tests__/unified-account-selection.test.ts
+++ b/apps/frontend/src/main/claude-profile/__tests__/unified-account-selection.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for getBestAvailableUnifiedAccount (profile-scorer.ts)
+ *
+ * Verifies the core scenario: when all OAuth profiles are rate-limited,
+ * API profiles (GLM, etc.) are correctly selected as alternatives.
+ * This is the foundation of the terminal unified swap fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { getBestAvailableUnifiedAccount } from '../profile-scorer';
+import type { ClaudeProfile, ClaudeAutoSwitchSettings, APIProfile } from '../../../shared/types';
+
+function createOAuthProfile(overrides: Partial<ClaudeProfile> = {}): ClaudeProfile {
+  return {
+    id: 'profile-1',
+    name: 'Account 1',
+    isDefault: false,
+    configDir: '/tmp/config',
+    usage: { weeklyUsagePercent: 50, sessionUsagePercent: 50 },
+    rateLimitEvents: [],
+    ...overrides,
+  } as ClaudeProfile;
+}
+
+function createAPIProfile(overrides: Partial<APIProfile> = {}): APIProfile {
+  return {
+    id: 'glm-1',
+    name: 'GLM API',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    apiKey: 'sk-glm-key',
+    ...overrides,
+  } as APIProfile;
+}
+
+const defaultSettings = {
+  enabled: true,
+  autoSwitchOnRateLimit: true,
+  proactiveSwapEnabled: true,
+  usageCheckInterval: 30000,
+  sessionThreshold: 95,
+  weeklyThreshold: 99,
+  autoSwitchOnAuthFailure: false,
+} as ClaudeAutoSwitchSettings;
+
+describe('getBestAvailableUnifiedAccount', () => {
+  it('returns API profile when all OAuth profiles are rate-limited', () => {
+    const rateLimitedOAuth = createOAuthProfile({
+      id: 'oauth-1',
+      name: 'Rate Limited Account',
+      rateLimitEvents: [
+        {
+          type: 'session',
+          hitAt: new Date(),
+          resetAt: new Date(Date.now() + 3600000),
+          resetTimeString: 'Feb 19 at 11am',
+        }
+      ],
+    });
+
+    const glmProfile = createAPIProfile({
+      id: 'glm-1',
+      name: 'GLM API',
+    });
+
+    const result = getBestAvailableUnifiedAccount(
+      [rateLimitedOAuth],
+      [glmProfile],
+      defaultSettings,
+      { excludeAccountId: 'oauth-oauth-1' }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('api');
+    expect(result!.name).toBe('GLM API');
+  });
+
+  it('returns available OAuth profile over API when OAuth is not rate-limited', () => {
+    const healthyOAuth = createOAuthProfile({
+      id: 'oauth-1',
+      name: 'Healthy Account',
+    });
+
+    const glmProfile = createAPIProfile();
+
+    const result = getBestAvailableUnifiedAccount(
+      [healthyOAuth],
+      [glmProfile],
+      defaultSettings,
+      { excludeAccountId: 'some-other-id' }
+    );
+
+    expect(result).not.toBeNull();
+    // Both are available; result depends on priority order
+    expect(result!.isAvailable).toBe(true);
+  });
+
+  it('returns API profile when OAuth is at capacity (100% weekly usage)', () => {
+    const atCapacityOAuth = createOAuthProfile({
+      id: 'oauth-1',
+      name: 'At Capacity Account',
+      usage: {
+        weeklyUsagePercent: 100,
+        sessionUsagePercent: 100,
+        sessionResetTime: '11:59pm',
+        weeklyResetTime: 'Feb 20',
+        lastUpdated: new Date(),
+      },
+    });
+
+    const glmProfile = createAPIProfile();
+
+    const result = getBestAvailableUnifiedAccount(
+      [atCapacityOAuth],
+      [glmProfile],
+      defaultSettings,
+      { excludeAccountId: 'oauth-oauth-1' }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('api');
+    expect(result!.isAvailable).toBe(true);
+  });
+
+  it('returns null when no profiles exist', () => {
+    const result = getBestAvailableUnifiedAccount(
+      [],
+      [],
+      defaultSettings,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns API profile even when it is the only option', () => {
+    const glmProfile = createAPIProfile({
+      id: 'glm-1',
+      name: 'GLM API',
+      apiKey: 'sk-valid-key',
+    });
+
+    const result = getBestAvailableUnifiedAccount(
+      [],
+      [glmProfile],
+      defaultSettings,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('api');
+    expect(result!.hasUnlimitedUsage).toBe(true);
+  });
+
+  it('respects priority order when multiple accounts are available', () => {
+    const oauth = createOAuthProfile({ id: 'oauth-1', name: 'OAuth' });
+    const glm = createAPIProfile({ id: 'glm-1', name: 'GLM' });
+
+    // GLM first in priority
+    const result = getBestAvailableUnifiedAccount(
+      [oauth],
+      [glm],
+      defaultSettings,
+      { priorityOrder: ['api-glm-1', 'oauth-oauth-1'] }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('GLM');
+    expect(result!.type).toBe('api');
+  });
+
+  it('excludes the specified account from selection', () => {
+    const glm = createAPIProfile({ id: 'glm-1', name: 'GLM' });
+
+    const result = getBestAvailableUnifiedAccount(
+      [],
+      [glm],
+      defaultSettings,
+      { excludeAccountId: 'api-glm-1' }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('allows manual selection of API profile via priority order even when OAuth is healthy', () => {
+    const healthyOAuth = createOAuthProfile({
+      id: 'oauth-1',
+      name: 'Healthy OAuth',
+    });
+
+    const glm = createAPIProfile({ id: 'glm-1', name: 'GLM API' });
+
+    // User puts GLM first in priority → should get GLM
+    const result = getBestAvailableUnifiedAccount(
+      [healthyOAuth],
+      [glm],
+      defaultSettings,
+      { priorityOrder: ['api-glm-1', 'oauth-oauth-1'] }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('api');
+    expect(result!.name).toBe('GLM API');
+  });
+});

--- a/apps/frontend/src/main/claude-profile/__tests__/unified-account-selection.test.ts
+++ b/apps/frontend/src/main/claude-profile/__tests__/unified-account-selection.test.ts
@@ -15,6 +15,7 @@ function createOAuthProfile(overrides: Partial<ClaudeProfile> = {}): ClaudeProfi
     name: 'Account 1',
     isDefault: false,
     configDir: '/tmp/config',
+    oauthToken: 'fake-token-for-testing',
     usage: { weeklyUsagePercent: 50, sessionUsagePercent: 50 },
     rateLimitEvents: [],
     ...overrides,

--- a/apps/frontend/src/main/claude-profile/credential-utils.ts
+++ b/apps/frontend/src/main/claude-profile/credential-utils.ts
@@ -154,6 +154,7 @@ function isValidCredentialsPath(credentialsPath: string): boolean {
  * @returns The 8-character hex hash suffix
  */
 export function calculateConfigDirHash(configDir: string): string {
+  // CodeQL[js/weak-crypto-hashing] suppress False positive: hashing filesystem path for identifier, not password
   return createHash('sha256').update(configDir).digest('hex').slice(0, 8);
 }
 
@@ -731,6 +732,7 @@ function getSecretServiceAttribute(configDir?: string): string {
     return 'claude-code';
   }
   // For custom config dirs, create a hashed attribute to avoid conflicts
+  // CodeQL[js/weak-crypto-hashing] suppress False positive: hashing filesystem path for identifier, not password
   const hash = createHash('sha256').update(configDir).digest('hex').slice(0, 8);
   return `claude-code-${hash}`;
 }

--- a/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
+++ b/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
@@ -90,6 +90,12 @@ vi.mock('../pty-manager', () => ({
   writeToPty: mockWriteToPty,
 }));
 
+// Mock setActiveAPIProfile for handleRateLimit API profile auto-switch
+const mockSetActiveAPIProfile = vi.fn().mockResolvedValue({});
+vi.mock('../../services/profile/profile-manager', () => ({
+  setActiveAPIProfile: mockSetActiveAPIProfile,
+}));
+
 vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
   return {
@@ -1115,6 +1121,178 @@ describe('claude-integration-handler - Helper Functions', () => {
 
       // Tab instead of space doesn't match
       expect(shouldAutoRenameTerminal('Terminal\t1')).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // handleRateLimit — Unified account selection (OAuth + API)
+  // ===========================================================================
+  describe('handleRateLimit - unified account selection', () => {
+    const mockExtractRateLimitReset = vi.fn();
+    const mockBestAvailableUnifiedAccount = vi.fn();
+    const mockRecordRateLimitEvent = vi.fn().mockReturnValue({ type: 'session' });
+    const mockGetAutoSwitchSettings = vi.fn();
+    const mockSwitchProfileCallback = vi.fn().mockResolvedValue(undefined);
+    const mockSendIpc = vi.fn();
+
+    function createRateLimitTestContext() {
+      const terminal = createMockTerminal({ claudeProfileId: 'oauth-1' });
+      const lastNotified = new Map<string, string>();
+
+      mockExtractRateLimitReset.mockReturnValue('Feb 19 at 11am');
+      mockBestAvailableUnifiedAccount.mockResolvedValue(null);
+      mockGetAutoSwitchSettings.mockReturnValue({
+        enabled: true,
+        autoSwitchOnRateLimit: true,
+      });
+
+      mockGetClaudeProfileManager.mockReturnValue({
+        recordRateLimitEvent: mockRecordRateLimitEvent,
+        getAutoSwitchSettings: mockGetAutoSwitchSettings,
+        getBestAvailableUnifiedAccount: mockBestAvailableUnifiedAccount,
+      });
+
+      const getWindow = vi.fn().mockReturnValue({
+        webContents: { send: mockSendIpc },
+      });
+
+      return { terminal, lastNotified, getWindow };
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('sends IPC event with suggestedAccountType for API profiles', async () => {
+      // Override extractRateLimitReset for this test
+      vi.doMock('../output-parser', () => ({
+        extractRateLimitReset: () => 'Feb 19 at 11am',
+      }));
+
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockBestAvailableUnifiedAccount.mockResolvedValue({
+        id: 'api-glm-1',
+        name: 'GLM API',
+        type: 'api',
+        isAvailable: true,
+      });
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      // Wait for async unified account selection
+      await vi.waitFor(() => {
+        expect(mockSendIpc).toHaveBeenCalled();
+      });
+
+      const ipcPayload = mockSendIpc.mock.calls[0][1];
+      expect(ipcPayload.suggestedAccountType).toBe('api');
+      expect(ipcPayload.suggestedProfileId).toBe('api-glm-1');
+      expect(ipcPayload.suggestedProfileName).toBe('GLM API');
+    });
+
+    it('calls setActiveAPIProfile (not switchProfileCallback) when auto-switching to API profile', async () => {
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockBestAvailableUnifiedAccount.mockResolvedValue({
+        id: 'api-glm-1',
+        name: 'GLM API',
+        type: 'api',
+        isAvailable: true,
+      });
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      await vi.waitFor(() => {
+        expect(mockSetActiveAPIProfile).toHaveBeenCalledWith('api-glm-1');
+      });
+
+      // switchProfileCallback should NOT be called for API profiles
+      expect(mockSwitchProfileCallback).not.toHaveBeenCalled();
+    });
+
+    it('calls switchProfileCallback (not setActiveAPIProfile) when auto-switching to OAuth profile', async () => {
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockBestAvailableUnifiedAccount.mockResolvedValue({
+        id: 'oauth-2',
+        name: 'Account 2',
+        type: 'oauth',
+        isAvailable: true,
+      });
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      await vi.waitFor(() => {
+        expect(mockSwitchProfileCallback).toHaveBeenCalledWith('term-1', 'oauth-2');
+      });
+
+      // setActiveAPIProfile should NOT be called for OAuth profiles
+      expect(mockSetActiveAPIProfile).not.toHaveBeenCalled();
+    });
+
+    it('sends IPC event without suggested profile when unified account selection fails', async () => {
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockBestAvailableUnifiedAccount.mockRejectedValue(new Error('Profile load failed'));
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      // Wait for the error fallback path
+      await vi.waitFor(() => {
+        expect(mockSendIpc).toHaveBeenCalled();
+      });
+
+      const ipcPayload = mockSendIpc.mock.calls[0][1];
+      expect(ipcPayload.suggestedProfileId).toBeUndefined();
+      expect(ipcPayload.suggestedAccountType).toBeUndefined();
+    });
+
+    it('does not auto-switch when autoSwitchOnRateLimit is disabled', async () => {
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockGetAutoSwitchSettings.mockReturnValue({
+        enabled: true,
+        autoSwitchOnRateLimit: false,
+      });
+
+      mockBestAvailableUnifiedAccount.mockResolvedValue({
+        id: 'api-glm-1',
+        name: 'GLM API',
+        type: 'api',
+        isAvailable: true,
+      });
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      await vi.waitFor(() => {
+        expect(mockSendIpc).toHaveBeenCalled();
+      });
+
+      // Neither switch mechanism should be called
+      expect(mockSetActiveAPIProfile).not.toHaveBeenCalled();
+      expect(mockSwitchProfileCallback).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-switch when no best account is available', async () => {
+      const { handleRateLimit } = await import('../claude-integration-handler');
+      const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
+
+      mockBestAvailableUnifiedAccount.mockResolvedValue(null);
+
+      handleRateLimit(terminal, 'Limit reached · resets Feb 19 at 11am', lastNotified, getWindow, mockSwitchProfileCallback);
+
+      await vi.waitFor(() => {
+        expect(mockSendIpc).toHaveBeenCalled();
+      });
+
+      expect(mockSetActiveAPIProfile).not.toHaveBeenCalled();
+      expect(mockSwitchProfileCallback).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
+++ b/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
@@ -1295,4 +1295,57 @@ describe('claude-integration-handler - Helper Functions', () => {
       expect(mockSwitchProfileCallback).not.toHaveBeenCalled();
     });
   });
+
+  // ===========================================================================
+  // Proactive swap — respects manual profile selections
+  // ===========================================================================
+  describe('proactive swap respects manual profile selection', () => {
+    it('does not run proactive swap when profileId is explicitly provided (manual switch)', async () => {
+      // Set up a profile manager where getBestAvailableUnifiedAccount would swap
+      // to a different profile if called — proving it was NOT called.
+      const mockBestUnified = vi.fn().mockResolvedValue({
+        id: 'api-glm-1',
+        name: 'GLM API',
+        type: 'api',
+        isAvailable: true,
+      });
+      const profileManager = {
+        getActiveProfile: vi.fn(() => ({
+          id: 'oauth-1', name: 'Account 1', isDefault: true,
+        })),
+        getProfile: vi.fn((id: string) => ({
+          id, name: 'Manually Selected', isDefault: false,
+          configDir: '/tmp/manual-config',
+        })),
+        getAutoSwitchSettings: vi.fn(() => ({
+          enabled: true, autoSwitchOnRateLimit: true,
+        })),
+        getBestAvailableUnifiedAccount: mockBestUnified,
+        getProfileToken: vi.fn(() => null),
+        markProfileUsed: vi.fn(),
+        setActiveProfile: vi.fn(),
+      };
+
+      mockGetClaudeCliInvocationAsync.mockResolvedValue({
+        command: '/opt/claude/bin/claude',
+        env: { PATH: '/opt/claude/bin:/usr/bin' },
+      });
+      mockInitializeClaudeProfileManager.mockResolvedValue(profileManager);
+      mockGetClaudeProfileManager.mockReturnValue(profileManager);
+
+      const terminal = createMockTerminal();
+      const { invokeClaudeAsync } = await import('../claude-integration-handler');
+
+      // Provide an explicit profileId — simulating a manual switch
+      await invokeClaudeAsync(terminal, '/tmp/project', 'manual-profile-1', () => null, vi.fn());
+
+      // getBestAvailableUnifiedAccount should NOT have been called
+      // because proactive swap is skipped when profileId is explicit
+      expect(mockBestUnified).not.toHaveBeenCalled();
+
+      // The explicit profile should be used, not the auto-selected one
+      expect(profileManager.getProfile).toHaveBeenCalledWith('manual-profile-1');
+      expect(profileManager.markProfileUsed).toHaveBeenCalledWith('manual-profile-1');
+    });
+  });
 });

--- a/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
+++ b/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
@@ -1164,11 +1164,6 @@ describe('claude-integration-handler - Helper Functions', () => {
     });
 
     it('sends IPC event with suggestedAccountType for API profiles', async () => {
-      // Override extractRateLimitReset for this test
-      vi.doMock('../output-parser', () => ({
-        extractRateLimitReset: () => 'Feb 19 at 11am',
-      }));
-
       const { handleRateLimit } = await import('../claude-integration-handler');
       const { terminal, lastNotified, getWindow } = createRateLimitTestContext();
 

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -399,7 +399,41 @@ export function finalizeClaudeInvoke(
 }
 
 /**
- * Handle rate limit detection and profile switching
+ * Proactive profile swap: check if any better profile (OAuth or API) is available
+ * before invoking Claude. If the active profile is rate-limited or at capacity,
+ * swap to the best available unified account and persist the change globally.
+ *
+ * Safe to call from both sync and async invoke paths — errors are caught
+ * and logged, never propagated to the caller.
+ */
+async function ensureBestProfileActive(): Promise<void> {
+  try {
+    const profileManager = getClaudeProfileManager();
+    const activeProfile = profileManager.getActiveProfile();
+    const bestAccount = await profileManager.getBestAvailableUnifiedAccount(activeProfile.id);
+
+    if (bestAccount) {
+      if (bestAccount.type === 'api') {
+        const { setActiveAPIProfile } = await import('../services/profile/profile-manager');
+        await setActiveAPIProfile(bestAccount.id);
+      } else {
+        profileManager.setActiveProfile(bestAccount.id);
+      }
+      debugLog('[ClaudeIntegration] Proactive profile swap:', {
+        from: activeProfile.name,
+        to: bestAccount.name,
+        type: bestAccount.type,
+      });
+    }
+  } catch (err) {
+    debugError('[ClaudeIntegration] Proactive swap check failed (continuing with current profile):', err);
+  }
+}
+
+/**
+ * Handle rate limit detection and profile switching.
+ * Uses unified account selection (OAuth + API) so terminals can swap to
+ * API profiles like GLM when all OAuth profiles are rate-limited.
  */
 export function handleRateLimit(
   terminal: TerminalProcess,
@@ -432,29 +466,58 @@ export function handleRateLimit(
   }
 
   const autoSwitchSettings = profileManager.getAutoSwitchSettings();
-  const bestProfile = profileManager.getBestAvailableProfile(currentProfileId);
 
-  const win = getWindow();
-  if (win) {
-    win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
-      terminalId: terminal.id,
-      resetTime,
-      detectedAt: new Date().toISOString(),
-      profileId: currentProfileId,
-      suggestedProfileId: bestProfile?.id,
-      suggestedProfileName: bestProfile?.name,
-      autoSwitchEnabled: autoSwitchSettings.autoSwitchOnRateLimit
-    } as RateLimitEvent);
-  }
+  // Use unified account selection (OAuth + API) instead of OAuth-only
+  profileManager.getBestAvailableUnifiedAccount(currentProfileId).then(bestAccount => {
+    const win = getWindow();
+    if (win) {
+      win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
+        terminalId: terminal.id,
+        resetTime,
+        detectedAt: new Date().toISOString(),
+        profileId: currentProfileId,
+        suggestedProfileId: bestAccount?.id,
+        suggestedProfileName: bestAccount?.name,
+        suggestedAccountType: bestAccount?.type,
+        autoSwitchEnabled: autoSwitchSettings.autoSwitchOnRateLimit
+      } as RateLimitEvent);
+    }
 
-  if (autoSwitchSettings.enabled && autoSwitchSettings.autoSwitchOnRateLimit && bestProfile) {
-    console.warn('[ClaudeIntegration] Auto-switching to profile:', bestProfile.name);
-    switchProfileCallback(terminal.id, bestProfile.id).then(_result => {
-      console.warn('[ClaudeIntegration] Auto-switch completed');
-    }).catch(err => {
-      console.error('[ClaudeIntegration] Auto-switch failed:', err);
-    });
-  }
+    if (autoSwitchSettings.enabled && autoSwitchSettings.autoSwitchOnRateLimit && bestAccount) {
+      console.warn('[ClaudeIntegration] Auto-switching to account:', bestAccount.name, '(type:', bestAccount.type, ')');
+
+      if (bestAccount.type === 'api') {
+        // API profile: persist globally via setActiveAPIProfile
+        import('../services/profile/profile-manager').then(({ setActiveAPIProfile }) => {
+          return setActiveAPIProfile(bestAccount.id);
+        }).then(() => {
+          console.warn('[ClaudeIntegration] API profile auto-switch completed:', bestAccount.name);
+        }).catch(err => {
+          console.error('[ClaudeIntegration] API profile auto-switch failed:', err);
+        });
+      } else {
+        // OAuth profile: use existing callback
+        switchProfileCallback(terminal.id, bestAccount.id).then(() => {
+          console.warn('[ClaudeIntegration] OAuth profile auto-switch completed');
+        }).catch(err => {
+          console.error('[ClaudeIntegration] OAuth profile auto-switch failed:', err);
+        });
+      }
+    }
+  }).catch(err => {
+    // Fallback: send IPC event without suggested profile
+    console.error('[ClaudeIntegration] Unified account selection failed:', err);
+    const win = getWindow();
+    if (win) {
+      win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
+        terminalId: terminal.id,
+        resetTime,
+        detectedAt: new Date().toISOString(),
+        profileId: currentProfileId,
+        autoSwitchEnabled: autoSwitchSettings.autoSwitchOnRateLimit
+      } as RateLimitEvent);
+    }
+  });
 }
 
 /**
@@ -1088,6 +1151,10 @@ export function invokeClaude(
     SessionHandler.releaseSessionId(terminal.id);
     terminal.claudeSessionId = undefined;
 
+    // Fire-and-forget proactive swap: if a swap is needed, it persists globally
+    // so the profile check later in this function will pick it up on next invocation.
+    ensureBestProfileActive().catch(() => {/* handled internally */});
+
     const startTime = Date.now();
     const projectPath = cwd || terminal.projectPath || terminal.cwd;
 
@@ -1279,6 +1346,10 @@ export async function invokeClaudeAsync(
     terminal.dangerouslySkipPermissions = dangerouslySkipPermissions;
     SessionHandler.releaseSessionId(terminal.id);
     terminal.claudeSessionId = undefined;
+
+    // Proactive swap: check if current profile is rate-limited/at-capacity
+    // and switch to a better profile (OAuth or API) before building the command.
+    await ensureBestProfileActive();
 
     const projectPath = cwd || terminal.projectPath || terminal.cwd;
 

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -17,6 +17,7 @@ import * as OutputParser from './output-parser';
 import * as SessionHandler from './session-handler';
 import * as PtyManager from './pty-manager';
 import { debugLog, debugError } from '../../shared/utils/debug-logger';
+import { toOAuthUnifiedId } from '../../shared/utils/unified-account';
 import { escapeShellArg, escapeForWindowsDoubleQuote, buildCdCommand } from '../../shared/utils/shell-escape';
 import { getClaudeCliInvocation, getClaudeCliInvocationAsync } from '../claude-cli-utils';
 import { isWindows } from '../platform';
@@ -399,6 +400,53 @@ export function finalizeClaudeInvoke(
 }
 
 /**
+ * Build and send a RateLimitEvent IPC payload to the renderer.
+ *
+ * Centralises the IPC construction so it cannot drift between the success
+ * and error paths in handleRateLimit().
+ */
+function sendRateLimitIpc(
+  getWindow: WindowGetter,
+  terminalId: string,
+  resetTime: string,
+  profileId: string,
+  autoSwitchEnabled: boolean,
+  bestAccount?: { id: string; name: string; type: string } | null
+): void {
+  const win = getWindow();
+  if (win) {
+    win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
+      terminalId,
+      resetTime,
+      detectedAt: new Date().toISOString(),
+      profileId,
+      suggestedProfileId: bestAccount?.id,
+      suggestedProfileName: bestAccount?.name,
+      suggestedAccountType: bestAccount?.type,
+      autoSwitchEnabled,
+    } as RateLimitEvent);
+  }
+}
+
+/**
+ * Switch globally to a unified account (API or OAuth).
+ *
+ * API profiles are persisted via setActiveAPIProfile (lazy-imported).
+ * OAuth profiles are persisted via profileManager.setActiveProfile.
+ */
+async function switchToUnifiedAccount(
+  profileManager: ReturnType<typeof getClaudeProfileManager>,
+  account: { id: string; type: string }
+): Promise<void> {
+  if (account.type === 'api') {
+    const { setActiveAPIProfile } = await import('../services/profile/profile-manager');
+    await setActiveAPIProfile(account.id);
+  } else {
+    profileManager.setActiveProfile(account.id);
+  }
+}
+
+/**
  * Proactive profile swap: check if any better profile (OAuth or API) is available
  * before invoking Claude. If the active profile is rate-limited or at capacity,
  * swap to the best available unified account and persist the change globally.
@@ -410,15 +458,12 @@ async function ensureBestProfileActive(): Promise<void> {
   try {
     const profileManager = getClaudeProfileManager();
     const activeProfile = profileManager.getActiveProfile();
-    const bestAccount = await profileManager.getBestAvailableUnifiedAccount(activeProfile.id);
+    const bestAccount = await profileManager.getBestAvailableUnifiedAccount(
+      toOAuthUnifiedId(activeProfile.id)
+    );
 
     if (bestAccount) {
-      if (bestAccount.type === 'api') {
-        const { setActiveAPIProfile } = await import('../services/profile/profile-manager');
-        await setActiveAPIProfile(bestAccount.id);
-      } else {
-        profileManager.setActiveProfile(bestAccount.id);
-      }
+      await switchToUnifiedAccount(profileManager, bestAccount);
       debugLog('[ClaudeIntegration] Proactive profile swap:', {
         from: activeProfile.name,
         to: bestAccount.name,
@@ -468,20 +513,9 @@ export function handleRateLimit(
   const autoSwitchSettings = profileManager.getAutoSwitchSettings();
 
   // Use unified account selection (OAuth + API) instead of OAuth-only
-  profileManager.getBestAvailableUnifiedAccount(currentProfileId).then(bestAccount => {
-    const win = getWindow();
-    if (win) {
-      win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
-        terminalId: terminal.id,
-        resetTime,
-        detectedAt: new Date().toISOString(),
-        profileId: currentProfileId,
-        suggestedProfileId: bestAccount?.id,
-        suggestedProfileName: bestAccount?.name,
-        suggestedAccountType: bestAccount?.type,
-        autoSwitchEnabled: autoSwitchSettings.autoSwitchOnRateLimit
-      } as RateLimitEvent);
-    }
+  // Pass a properly-prefixed unified ID so the exclude filter works correctly
+  profileManager.getBestAvailableUnifiedAccount(toOAuthUnifiedId(currentProfileId)).then(bestAccount => {
+    sendRateLimitIpc(getWindow, terminal.id, resetTime, currentProfileId, autoSwitchSettings.autoSwitchOnRateLimit, bestAccount);
 
     if (autoSwitchSettings.enabled && autoSwitchSettings.autoSwitchOnRateLimit && bestAccount) {
       console.warn('[ClaudeIntegration] Auto-switching to account:', bestAccount.name, '(type:', bestAccount.type, ')');
@@ -496,7 +530,7 @@ export function handleRateLimit(
           console.error('[ClaudeIntegration] API profile auto-switch failed:', err);
         });
       } else {
-        // OAuth profile: use existing callback
+        // OAuth profile: use existing callback (restarts terminal, not just setActiveProfile)
         switchProfileCallback(terminal.id, bestAccount.id).then(() => {
           console.warn('[ClaudeIntegration] OAuth profile auto-switch completed');
         }).catch(err => {
@@ -507,16 +541,7 @@ export function handleRateLimit(
   }).catch(err => {
     // Fallback: send IPC event without suggested profile
     console.error('[ClaudeIntegration] Unified account selection failed:', err);
-    const win = getWindow();
-    if (win) {
-      win.webContents.send(IPC_CHANNELS.TERMINAL_RATE_LIMIT, {
-        terminalId: terminal.id,
-        resetTime,
-        detectedAt: new Date().toISOString(),
-        profileId: currentProfileId,
-        autoSwitchEnabled: autoSwitchSettings.autoSwitchOnRateLimit
-      } as RateLimitEvent);
-    }
+    sendRateLimitIpc(getWindow, terminal.id, resetTime, currentProfileId, autoSwitchSettings.autoSwitchOnRateLimit);
   });
 }
 

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -1151,9 +1151,11 @@ export function invokeClaude(
     SessionHandler.releaseSessionId(terminal.id);
     terminal.claudeSessionId = undefined;
 
-    // Fire-and-forget proactive swap: if a swap is needed, it persists globally
-    // so the profile check later in this function will pick it up on next invocation.
-    ensureBestProfileActive().catch(() => {/* handled internally */});
+    // Proactive swap only when no explicit profile was requested (i.e. not a manual switch).
+    // When profileId is set, the user explicitly chose a profile — respect that choice.
+    if (!profileId) {
+      ensureBestProfileActive().catch(() => {/* handled internally */});
+    }
 
     const startTime = Date.now();
     const projectPath = cwd || terminal.projectPath || terminal.cwd;
@@ -1347,9 +1349,11 @@ export async function invokeClaudeAsync(
     SessionHandler.releaseSessionId(terminal.id);
     terminal.claudeSessionId = undefined;
 
-    // Proactive swap: check if current profile is rate-limited/at-capacity
-    // and switch to a better profile (OAuth or API) before building the command.
-    await ensureBestProfileActive();
+    // Proactive swap only when no explicit profile was requested (i.e. not a manual switch).
+    // When profileId is set, the user explicitly chose a profile — respect that choice.
+    if (!profileId) {
+      await ensureBestProfileActive();
+    }
 
     const projectPath = cwd || terminal.projectPath || terminal.cwd;
 

--- a/apps/frontend/src/main/terminal/types.ts
+++ b/apps/frontend/src/main/terminal/types.ts
@@ -40,6 +40,7 @@ export interface RateLimitEvent {
   profileId: string;
   suggestedProfileId?: string;
   suggestedProfileName?: string;
+  suggestedAccountType?: 'oauth' | 'api';
   autoSwitchEnabled: boolean;
 }
 


### PR DESCRIPTION
## Problem

When all OAuth profiles are rate-limited, terminals running Claude Code cannot automatically fall back to API profiles (GLM, etc.). Users hit a hard stop even though they have valid API credentials configured.

## Solution

Add **unified account selection** to the terminal's rate limit handler and proactive swap logic:

- **Reactive swap**: When rate limit is detected, `handleRateLimit()` now calls `getBestAvailableUnifiedAccount()` which considers BOTH OAuth and API profiles. If an API profile is available, it's suggested (and auto-switched if enabled).
- **Proactive swap**: Before Claude invocation, `ensureBestProfileActive()` checks if a better profile (OAuth or API) is available and swaps globally.
- **Manual swap guard**: Proactive swap is skipped when a user explicitly selects a profile, respecting their choice.

## Changes

- `claude-integration-handler.ts`: Added `ensureBestProfileActive()` helper, rewrote `handleRateLimit()` to use unified account selection
- `types.ts`: Added `suggestedAccountType` field to `RateLimitEvent` IPC payload
- Tests: 90 tests pass (82 terminal + 8 profile-scorer verification tests)
- Refactored: Extracted `sendRateLimitIpc()` and `switchToUnifiedAccount()` helpers to eliminate duplication

## Testing

- **Unit tests**: 90/90 pass
- **TypeScript**: Clean
- **Biome lint**: Clean
- **Manual verification**: Debug logs show `[ClaudeIntegration] Auto-switching to account: GLM API (type: api)` when OAuth is rate-limited

## ⚠️ Platform Note

This fix addresses the core logic for unified account selection. **We believe this resolves the Windows OAuth/API rate limit swap issues**, but we don't have 100% confirmation that it fixes all edge cases on Windows. The logic is platform-agnostic and uses the same cross-platform abstractions as the rest of the codebase.

Community testing on Windows would be appreciated to confirm the fix works end-to-end.

## Related

This is the terminal-focused portion of the unified account selection work, building on the existing `getBestAvailableUnifiedAccount()` infrastructure in `profile-scorer.ts` and `claude-profile-manager.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic fallback to API profiles when OAuth profiles are rate-limited
  * Proactive profile optimization before Claude operations (background profile swap when none explicitly selected)
  * Rate-limit events now include suggested account type and better auto-switch behavior

* **Tests**
  * Added comprehensive tests covering rate-limit handling, unified account selection, proactive swaps, and manual vs. automatic selection paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->