### PR TITLE
fix: replace .claude symlinks with copies for sandboxed agents

### DIFF
--- a/apps/backend/core/workspace/setup.py
+++ b/apps/backend/core/workspace/setup.py
@@ -263,15 +263,19 @@ def copy_claude_config_to_worktree(
             )
             return copied
 
-    # If target already exists as a real directory, remove it to get a fresh copy
+    # If target already exists as a real directory or file, remove it to get a fresh copy
     if target_path.exists():
-        debug(MODULE, "Removing existing .claude/ directory to refresh copy")
         try:
-            shutil.rmtree(target_path)
+            if target_path.is_dir():
+                debug(MODULE, "Removing existing .claude/ directory to refresh copy")
+                shutil.rmtree(target_path)
+            else:
+                debug(MODULE, "Removing existing .claude/ file to refresh copy")
+                target_path.unlink()
         except (OSError, shutil.Error) as e:
-            debug_warning(MODULE, f"Could not remove existing .claude/ directory: {e}")
+            debug_warning(MODULE, f"Could not remove existing .claude/ target: {e}")
             print_status(
-                "Warning: Could not refresh .claude/ directory in worktree",
+                "Warning: Could not refresh .claude/ in worktree",
                 "warning",
             )
             return copied

--- a/apps/backend/core/workspace/setup.py
+++ b/apps/backend/core/workspace/setup.py
@@ -217,73 +217,87 @@ def symlink_node_modules_to_worktree(
     return [path for paths in results.values() for path in paths]
 
 
-def symlink_claude_config_to_worktree(
+def copy_claude_config_to_worktree(
     project_dir: Path, worktree_path: Path
 ) -> list[str]:
     """
-    Symlink .claude/ directory from project root to worktree.
+    Copy .claude/ directory from project root into the worktree.
 
-    This ensures the worktree has access to Claude Code configuration
-    (settings, CLAUDE.md, MCP servers, etc.) so that terminals opened
-    in the worktree behave identically to the project root.
+    Agents run in a sandboxed filesystem restricted to the worktree path,
+    so symlinks pointing outside the worktree (to the original project dir)
+    are not accessible. A physical copy ensures agents can read .claude/rules/
+    and other configuration files directly.
+
+    This replaces the previous symlink approach which failed due to sandbox
+    restrictions. If a symlink already exists at the target, it is removed
+    before copying.
 
     Args:
         project_dir: The main project directory
         worktree_path: Path to the worktree
 
     Returns:
-        List of symlinked paths (relative to worktree)
+        List of copied paths (relative to worktree)
     """
-    symlinked = []
+    copied = []
 
     source_path = project_dir / ".claude"
     target_path = worktree_path / ".claude"
 
     # Skip if source doesn't exist
     if not source_path.exists():
-        debug(MODULE, "Skipping .claude/ - source does not exist")
-        return symlinked
+        debug(MODULE, "Skipping .claude/ copy - source does not exist")
+        return copied
 
-    # Skip if target already exists
-    if target_path.exists():
-        debug(MODULE, "Skipping .claude/ - target already exists")
-        return symlinked
-
-    # Also skip if target is a symlink (even if broken)
+    # If target is a symlink (from a previous run or old code), remove it
+    # so we can replace it with a real copy
     if target_path.is_symlink():
-        debug(MODULE, "Skipping .claude/ - symlink already exists (possibly broken)")
-        return symlinked
+        debug(MODULE, "Removing existing .claude/ symlink to replace with copy")
+        try:
+            target_path.unlink()
+        except OSError as e:
+            debug_warning(MODULE, f"Could not remove .claude/ symlink: {e}")
+            print_status(
+                "Warning: Could not remove existing .claude/ symlink",
+                "warning",
+            )
+            return copied
+
+    # If target already exists as a real directory, remove it to get a fresh copy
+    if target_path.exists():
+        debug(MODULE, "Removing existing .claude/ directory to refresh copy")
+        try:
+            shutil.rmtree(target_path)
+        except (OSError, shutil.Error) as e:
+            debug_warning(MODULE, f"Could not remove existing .claude/ directory: {e}")
+            print_status(
+                "Warning: Could not refresh .claude/ directory in worktree",
+                "warning",
+            )
+            return copied
 
     # Ensure parent directory exists
     target_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        if sys.platform == "win32":
-            # On Windows, use junctions instead of symlinks (no admin rights required)
-            result = subprocess.run(
-                ["cmd", "/c", "mklink", "/J", str(target_path), str(source_path)],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise OSError(result.stderr or "mklink /J failed")
-        else:
-            # On macOS/Linux, use relative symlinks for portability
-            relative_source = os.path.relpath(source_path, target_path.parent)
-            os.symlink(relative_source, target_path)
-        symlinked.append(".claude")
-        debug(MODULE, f"Symlinked .claude/ -> {source_path}")
-    except OSError as e:
+        shutil.copytree(source_path, target_path)
+        copied.append(".claude")
+        debug(MODULE, f"Copied .claude/ to worktree from {source_path}")
+    except (OSError, shutil.Error) as e:
         debug_warning(
             MODULE,
-            f"Could not symlink .claude/: {e}. Claude Code features may not work in worktree terminals.",
+            f"Could not copy .claude/: {e}. Claude Code rules may not work in agent worktrees.",
         )
         print_status(
-            "Warning: Could not link .claude/ - Claude Code features may not work in terminals",
+            "Warning: Could not copy .claude/ - Claude Code rules may not work in agent worktrees",
             "warning",
         )
 
-    return symlinked
+    return copied
+
+
+# Backward-compatible alias for callers that reference the old name
+symlink_claude_config_to_worktree = copy_claude_config_to_worktree
 
 
 def copy_spec_to_worktree(
@@ -398,12 +412,14 @@ def setup_workspace(
                 f"Dependencies ({strategy_name}): {', '.join(paths)}", "success"
             )
 
-    # Symlink .claude/ config to worktree for Claude Code features (settings, commands, etc.)
-    symlinked_claude = symlink_claude_config_to_worktree(
+    # Copy .claude/ config to worktree for Claude Code features (rules, settings, etc.)
+    # Uses a physical copy instead of symlink because agents run in a sandboxed
+    # filesystem restricted to the worktree path and cannot follow symlinks outside it.
+    copied_claude = copy_claude_config_to_worktree(
         project_dir, worktree_info.path
     )
-    if symlinked_claude:
-        print_status(f"Claude config linked: {', '.join(symlinked_claude)}", "success")
+    if copied_claude:
+        print_status(f"Claude config copied: {', '.join(copied_claude)}", "success")
 
     # Copy security configuration files if they exist
     # Note: Unlike env files, security files always overwrite to ensure

--- a/apps/backend/runners/github/gh_client.py
+++ b/apps/backend/runners/github/gh_client.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from core.gh_executable import get_gh_executable
+from core.platform import get_binary_directories, get_path_delimiter, is_macos
 
 try:
     from .rate_limiter import RateLimiter, RateLimitExceeded
@@ -109,6 +111,49 @@ class GHClient:
         if enable_rate_limiting:
             self._rate_limiter = RateLimiter.get_instance()
 
+        # Build subprocess environment once at init
+        self._subprocess_env = self._build_subprocess_env()
+
+    @staticmethod
+    def _build_subprocess_env() -> dict[str, str]:
+        """Build an augmented environment for gh CLI subprocess calls.
+
+        When Electron launches from Finder/Dock on macOS, the process inherits
+        a stripped-down PATH that may not include Homebrew or other common tool
+        directories. This method augments PATH with platform-appropriate binary
+        directories so that `gh` (and tools it invokes like `git`) can be found.
+
+        Also forwards GH_TOKEN / GITHUB_TOKEN if present in the parent env,
+        ensuring authentication tokens propagate to subprocess calls.
+
+        Returns:
+            Environment dict suitable for asyncio.create_subprocess_exec(env=...).
+        """
+        env = os.environ.copy()
+
+        # Augment PATH with platform-specific binary directories
+        current_path = env.get("PATH", "")
+        delimiter = get_path_delimiter()
+        existing_dirs = set(current_path.split(delimiter))
+
+        bin_dirs = get_binary_directories()
+        extra_paths: list[str] = []
+
+        for directory in bin_dirs["system"] + bin_dirs["user"]:
+            if directory not in existing_dirs and os.path.isdir(directory):
+                extra_paths.append(directory)
+
+        # On macOS, also include Homebrew sbin (used by some git/gh dependencies)
+        if is_macos():
+            for sbin_path in ["/opt/homebrew/sbin", "/usr/local/sbin"]:
+                if sbin_path not in existing_dirs and os.path.isdir(sbin_path):
+                    extra_paths.append(sbin_path)
+
+        if extra_paths:
+            env["PATH"] = current_path + delimiter + delimiter.join(extra_paths)
+
+        return env
+
     async def run(
         self,
         args: list[str],
@@ -157,12 +202,13 @@ class GHClient:
                     f"Executing gh command (attempt {attempt}/{self.max_retries}): {' '.join(cmd)}"
                 )
 
-                # Create subprocess
+                # Create subprocess with augmented environment
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     cwd=self.project_dir,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=self._subprocess_env,
                 )
 
                 # Wait for completion with timeout

--- a/apps/frontend/src/main/insights/config.ts
+++ b/apps/frontend/src/main/insights/config.ts
@@ -8,6 +8,8 @@ import { getValidatedPythonPath } from '../python-detector';
 import { getAugmentedEnv } from '../env-utils';
 import { getEffectiveSourcePath } from '../updater/path-resolver';
 import { isWindows } from '../platform';
+import { getClaudeProfileManager } from '../claude-profile-manager';
+import { getCredentialsFromKeychain } from '../claude-profile/credential-utils';
 
 /**
  * Configuration manager for insights service
@@ -143,6 +145,26 @@ export class InsightsConfig {
     // are available even when app is launched from Finder/Dock.
     const augmentedEnv = getAugmentedEnv();
 
+    // Re-inject CLAUDE_CODE_OAUTH_TOKEN for the Insights subprocess.
+    //
+    // ensureCleanProfileEnv() clears CLAUDE_CODE_OAUTH_TOKEN when CLAUDE_CONFIG_DIR
+    // is set, because SDK-based agents can re-read fresh tokens from Keychain.
+    // However, the Insights runner uses core/auth.py directly, which shells out to
+    // `/usr/bin/security` for Keychain access — this fails under Electron's sandbox
+    // on macOS. We resolve this by reading the token here (in the main process,
+    // which has Keychain access) and passing it explicitly to the subprocess.
+    const oauthTokenEnv: Record<string, string> = {};
+    if (profileEnv.CLAUDE_CONFIG_DIR && !profileEnv.CLAUDE_CODE_OAUTH_TOKEN) {
+      const profileManager = getClaudeProfileManager();
+      const profile = profileManager.getProfile(profileResult.profileId);
+      if (profile?.configDir) {
+        const credentials = getCredentialsFromKeychain(profile.configDir, true);
+        if (credentials.token) {
+          oauthTokenEnv.CLAUDE_CODE_OAUTH_TOKEN = credentials.token;
+        }
+      }
+    }
+
     return {
       ...augmentedEnv,
       ...pythonEnv, // Include PYTHONPATH for bundled site-packages
@@ -150,6 +172,7 @@ export class InsightsConfig {
       ...oauthModeClearVars,
       ...profileEnv,
       ...apiProfileEnv,
+      ...oauthTokenEnv,
       PYTHONUNBUFFERED: '1',
       PYTHONIOENCODING: 'utf-8',
       PYTHONUTF8: '1',


### PR DESCRIPTION
## Description

This PR fixes agent access to Claude configuration files by replacing symlinks with physical copies in worktrees. Agents run in sandboxed filesystems restricted to the worktree path and cannot follow symlinks pointing outside it. Additionally, it improves subprocess environment handling for the GitHub CLI and Insights service to ensure tools can be found when launched from Finder/Dock on macOS.

## Changes

### Backend Workspace Setup
- **Renamed** `symlink_claude_config_to_worktree()` to `copy_claude_config_to_worktree()` to reflect the new behavior
- **Changed** from creating symlinks (Windows junctions, Unix symlinks) to using `shutil.copytree()` for a physical copy
- **Added** logic to remove existing symlinks or directories before copying to ensure fresh configuration
- **Updated** error handling and user-facing messages to reflect the copy operation
- **Added** backward-compatible alias for the old function name

### GitHub CLI Client
- **Added** `_build_subprocess_env()` method to augment PATH with platform-specific binary directories
- **Integrated** Homebrew paths on macOS (`/opt/homebrew/sbin`, `/usr/local/sbin`) to ensure `gh` and its dependencies can be found
- **Forwarded** authentication tokens (GH_TOKEN/GITHUB_TOKEN) to subprocess environment
- **Applied** augmented environment to subprocess calls via `env` parameter

### Insights Service Configuration
- **Added** logic to re-inject `CLAUDE_CODE_OAUTH_TOKEN` when `CLAUDE_CONFIG_DIR` is set
- **Reads** OAuth token from Keychain in the main process (which has access) and passes it to the Insights subprocess
- **Resolves** Keychain access failures that occur when the subprocess runs under Electron's sandbox on macOS

## Related Issue

Fixes agent configuration access in sandboxed worktrees and subprocess tool discovery on macOS.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [x] Backend
- [x] Fullstack

## Platform Testing Checklist

- [ ] **Windows tested**
- [x] **macOS tested** (Homebrew path handling, Keychain access)
- [ ] **Linux tested**
- [x] Used centralized `platform/` module for path delimiters and binary directories
- [x] No hardcoded paths (used `get_binary_directories()` and platform abstractions)

## CI/Testing Requirements

- [ ] All CI checks pass on all platforms
- [ ] Existing tests pass
- [ ] Changes are covered by existing test infrastructure

## Breaking Changes

**Breaking:** No

The backward-compatible alias `symlink_claude_config_to_worktree` ensures existing callers continue to work without modification.

https://claude.ai/code/session_01YJV16JVJkct1mWUMvy8vbH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Claude configuration now copies into worktrees for more reliable local setup and clearer success/error messages.
  * GitHub CLI invocations are more reliable across platforms (better PATH handling, improved tool discovery on macOS).
  * Insights authentication now injects stored Claude OAuth tokens into the Insights subprocess to ensure proper credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->