### PR TITLE
Fix insights chat context bleeding when switching conversations

### DIFF
--- a/apps/frontend/src/main/insights-service.ts
+++ b/apps/frontend/src/main/insights-service.ts
@@ -47,8 +47,8 @@ export class InsightsService extends EventEmitter {
     this.executor.on('stream-chunk', (projectId, chunk) => {
       this.emit('stream-chunk', projectId, chunk);
     });
-    this.executor.on('error', (projectId, error) => {
-      this.emit('error', projectId, error);
+    this.executor.on('error', (projectId, error, sessionId) => {
+      this.emit('error', projectId, error, sessionId);
     });
     this.executor.on('sdk-rate-limit', (info) => {
       this.emit('sdk-rate-limit', info);

--- a/apps/frontend/src/main/insights-service.ts
+++ b/apps/frontend/src/main/insights-service.ts
@@ -80,6 +80,8 @@ export class InsightsService extends EventEmitter {
    * Create a new session
    */
   createNewSession(projectId: string, projectPath: string): InsightsSession {
+    // Cancel any active streaming process to prevent orphaned processes
+    this.executor.cancelSession(projectId);
     return this.sessionManager.createNewSession(projectId, projectPath);
   }
 
@@ -155,17 +157,17 @@ export class InsightsService extends EventEmitter {
     // Cancel any existing session
     this.executor.cancelSession(projectId);
 
-    // Validate auto-claude source
-    const autoBuildSource = this.config.getAutoBuildSourcePath();
-    if (!autoBuildSource) {
-      this.emit('error', projectId, 'Auto Claude source not found');
-      return;
-    }
-
-    // Load or create session
+    // Load or create session early so we have a sessionId for error events
     let session = this.sessionManager.loadSession(projectId, projectPath);
     if (!session) {
       session = this.sessionManager.createNewSession(projectId, projectPath);
+    }
+
+    // Validate auto-claude source
+    const autoBuildSource = this.config.getAutoBuildSourcePath();
+    if (!autoBuildSource) {
+      this.emit('error', projectId, 'Auto Claude source not found', session.id);
+      return;
     }
 
     // Auto-generate title from first user message if still default

--- a/apps/frontend/src/main/insights-service.ts
+++ b/apps/frontend/src/main/insights-service.ts
@@ -87,6 +87,9 @@ export class InsightsService extends EventEmitter {
    * Switch to a different session
    */
   switchSession(projectId: string, projectPath: string, sessionId: string): InsightsSession | null {
+    // Cancel any active streaming process to prevent responses from the old session
+    // bleeding into the new one
+    this.executor.cancelSession(projectId);
     return this.sessionManager.switchSession(projectId, projectPath, sessionId);
   }
 
@@ -213,14 +216,15 @@ export class InsightsService extends EventEmitter {
     const configToUse = modelConfig || session.modelConfig;
 
     try {
-      // Execute insights query
+      // Execute insights query, passing sessionId so streaming events can be filtered
       const result = await this.executor.execute(
         projectId,
         projectPath,
         message,
         conversationHistory,
         configToUse,
-        images
+        images,
+        session.id
       );
 
       // Add assistant message to session

--- a/apps/frontend/src/main/insights/insights-executor.ts
+++ b/apps/frontend/src/main/insights/insights-executor.ts
@@ -96,6 +96,7 @@ export class InsightsExecutor extends EventEmitter {
     // Emit thinking status
     this.emit('status', projectId, {
       phase: 'thinking',
+      sessionId,
       message: 'Processing your message...'
     } as InsightsChatStatus);
 
@@ -288,7 +289,8 @@ export class InsightsExecutor extends EventEmitter {
           } as InsightsStreamChunk);
 
           this.emit('status', projectId, {
-            phase: 'complete'
+            phase: 'complete',
+            sessionId
           } as InsightsChatStatus);
 
           resolve({

--- a/apps/frontend/src/main/insights/insights-executor.ts
+++ b/apps/frontend/src/main/insights/insights-executor.ts
@@ -77,7 +77,8 @@ export class InsightsExecutor extends EventEmitter {
     message: string,
     conversationHistory: Array<{ role: string; content: string }>,
     modelConfig?: InsightsModelConfig,
-    images?: ImageAttachment[]
+    images?: ImageAttachment[],
+    sessionId?: string
   ): Promise<ProcessorResult> {
     // Cancel any existing session
     this.cancelSession(projectId);
@@ -243,19 +244,20 @@ export class InsightsExecutor extends EventEmitter {
         const lines = text.split('\n');
         for (const line of lines) {
           if (line.startsWith('__TASK_SUGGESTION__:')) {
-            this.handleTaskSuggestion(projectId, line, (task) => {
+            this.handleTaskSuggestion(projectId, sessionId, line, (task) => {
               if (task) {
                 suggestedTasks.push(task);
               }
             });
           } else if (line.startsWith('__TOOL_START__:')) {
-            this.handleToolStart(projectId, line, toolsUsed);
+            this.handleToolStart(projectId, sessionId, line, toolsUsed);
           } else if (line.startsWith('__TOOL_END__:')) {
-            this.handleToolEnd(projectId, line);
+            this.handleToolEnd(projectId, sessionId, line);
           } else if (line.trim()) {
             fullResponse += line + '\n';
             this.emit('stream-chunk', projectId, {
               type: 'text',
+              sessionId,
               content: line + '\n'
             } as InsightsStreamChunk);
           }
@@ -281,7 +283,8 @@ export class InsightsExecutor extends EventEmitter {
 
         if (code === 0) {
           this.emit('stream-chunk', projectId, {
-            type: 'done'
+            type: 'done',
+            sessionId
           } as InsightsStreamChunk);
 
           this.emit('status', projectId, {
@@ -301,6 +304,7 @@ export class InsightsExecutor extends EventEmitter {
           const error = `Process exited with code ${code}${stderrSummary}`;
           this.emit('stream-chunk', projectId, {
             type: 'error',
+            sessionId,
             error
           } as InsightsStreamChunk);
 
@@ -324,6 +328,7 @@ export class InsightsExecutor extends EventEmitter {
    */
   private handleTaskSuggestion(
     projectId: string,
+    sessionId: string | undefined,
     line: string,
     onTaskFound: (task: NonNullable<InsightsChatMessage['suggestedTasks']>[number]) => void
   ): void {
@@ -333,6 +338,7 @@ export class InsightsExecutor extends EventEmitter {
       onTaskFound(suggestedTask);
       this.emit('stream-chunk', projectId, {
         type: 'task_suggestion',
+        sessionId,
         suggestedTasks: [suggestedTask]
       } as InsightsStreamChunk);
     } catch {
@@ -345,6 +351,7 @@ export class InsightsExecutor extends EventEmitter {
    */
   private handleToolStart(
     projectId: string,
+    sessionId: string | undefined,
     line: string,
     toolsUsed: InsightsToolUsage[]
   ): void {
@@ -359,6 +366,7 @@ export class InsightsExecutor extends EventEmitter {
       });
       this.emit('stream-chunk', projectId, {
         type: 'tool_start',
+        sessionId,
         tool: {
           name: toolData.name,
           input: toolData.input
@@ -372,12 +380,13 @@ export class InsightsExecutor extends EventEmitter {
   /**
    * Handle tool end marker
    */
-  private handleToolEnd(projectId: string, line: string): void {
+  private handleToolEnd(projectId: string, sessionId: string | undefined, line: string): void {
     try {
       const toolJson = line.substring('__TOOL_END__:'.length);
       const toolData = JSON.parse(toolJson);
       this.emit('stream-chunk', projectId, {
         type: 'tool_end',
+        sessionId,
         tool: {
           name: toolData.name
         }

--- a/apps/frontend/src/main/insights/insights-executor.ts
+++ b/apps/frontend/src/main/insights/insights-executor.ts
@@ -310,7 +310,7 @@ export class InsightsExecutor extends EventEmitter {
             error
           } as InsightsStreamChunk);
 
-          this.emit('error', projectId, error);
+          this.emit('error', projectId, error, sessionId);
           reject(new Error(error));
         }
       });
@@ -319,7 +319,7 @@ export class InsightsExecutor extends EventEmitter {
         this.activeSessions.delete(projectId);
         cleanupTempFiles();
 
-        this.emit('error', projectId, err.message);
+        this.emit('error', projectId, err.message, sessionId);
         reject(err);
       });
     });

--- a/apps/frontend/src/main/ipc-handlers/insights-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/insights-handlers.ts
@@ -441,9 +441,9 @@ export function registerInsightsHandlers(getMainWindow: () => BrowserWindow | nu
     safeSendToRenderer(getMainWindow, IPC_CHANNELS.INSIGHTS_STATUS, projectId, status);
   });
 
-  // Forward errors to renderer
-  insightsService.on("error", (projectId: string, error: string) => {
-    safeSendToRenderer(getMainWindow, IPC_CHANNELS.INSIGHTS_ERROR, projectId, error);
+  // Forward errors to renderer (includes sessionId for session-level filtering)
+  insightsService.on("error", (projectId: string, error: string, sessionId?: string) => {
+    safeSendToRenderer(getMainWindow, IPC_CHANNELS.INSIGHTS_ERROR, projectId, error, sessionId);
   });
 
   // Forward SDK rate limit events to renderer

--- a/apps/frontend/src/main/ipc-handlers/insights-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/insights-handlers.ts
@@ -85,11 +85,14 @@ export function registerInsightsHandlers(getMainWindow: () => BrowserWindow | nu
     async (_, projectId: string, message: string, modelConfig?: InsightsModelConfig, images?: ImageAttachment[]) => {
       const project = projectStore.getProject(projectId);
       if (!project) {
+        // Include sessionId so the error isn't dropped by the frontend guard
+        const currentSession = insightsService.loadSession(projectId, '');
         safeSendToRenderer(
           getMainWindow,
           IPC_CHANNELS.INSIGHTS_ERROR,
           projectId,
-          "Project not found"
+          "Project not found",
+          currentSession?.id
         );
         return;
       }
@@ -120,11 +123,13 @@ export function registerInsightsHandlers(getMainWindow: () => BrowserWindow | nu
         // and ensure all error types are reported to the UI
         console.error("[Insights IPC] Error in sendMessage:", error);
         const errorMessage = error instanceof Error ? error.message : String(error);
+        const currentSession = insightsService.loadSession(projectId, project.path);
         safeSendToRenderer(
           getMainWindow,
           IPC_CHANNELS.INSIGHTS_ERROR,
           projectId,
-          `Failed to send message: ${errorMessage}`
+          `Failed to send message: ${errorMessage}`,
+          currentSession?.id
         );
       }
     }

--- a/apps/frontend/src/preload/api/modules/insights-api.ts
+++ b/apps/frontend/src/preload/api/modules/insights-api.ts
@@ -116,7 +116,7 @@ export const createInsightsAPI = (): InsightsAPI => ({
     createIpcListener(IPC_CHANNELS.INSIGHTS_STATUS, callback),
 
   onInsightsError: (
-    callback: (projectId: string, error: string) => void
+    callback: (projectId: string, error: string, sessionId?: string) => void
   ): IpcListenerCleanup =>
     createIpcListener(IPC_CHANNELS.INSIGHTS_ERROR, callback),
 

--- a/apps/frontend/src/preload/api/modules/insights-api.ts
+++ b/apps/frontend/src/preload/api/modules/insights-api.ts
@@ -45,7 +45,7 @@ export interface InsightsAPI {
     callback: (projectId: string, status: InsightsChatStatus) => void
   ) => IpcListenerCleanup;
   onInsightsError: (
-    callback: (projectId: string, error: string) => void
+    callback: (projectId: string, error: string, sessionId?: string) => void
   ) => IpcListenerCleanup;
   onInsightsSessionUpdated: (
     callback: (projectId: string, session: InsightsSession) => void

--- a/apps/frontend/src/renderer/stores/insights-store.ts
+++ b/apps/frontend/src/renderer/stores/insights-store.ts
@@ -487,13 +487,8 @@ export function setupInsightsListeners(): () => void {
   });
 
   // Listen for errors
-  // Note: error events carry (projectId, errorString) without sessionId in the payload.
-  // projectId validation is sufficient here because cancelSession() kills the process
-  // on session switch, and the stream-chunk listener (the primary bleeding vector) has
-  // full sessionId validation.
-  const unsubError = window.electronAPI.onInsightsError((projectId, error) => {
-    const currentSession = store().session;
-    if (!currentSession || currentSession.projectId !== projectId) return;
+  const unsubError = window.electronAPI.onInsightsError((projectId, error, sessionId) => {
+    if (!isActiveSession(projectId, sessionId)) return;
     store().setStatus({
       phase: 'error',
       error

--- a/apps/frontend/src/renderer/stores/insights-store.ts
+++ b/apps/frontend/src/renderer/stores/insights-store.ts
@@ -408,10 +408,11 @@ export function setupInsightsListeners(): () => void {
   const isActiveSession = (projectId: string, sessionId?: string): boolean => {
     const currentSession = store().session;
     if (!currentSession) return false;
-    // Validate projectId matches
     if (currentSession.projectId !== projectId) return false;
-    // If sessionId is provided in the chunk, validate it matches too
-    if (sessionId && currentSession.id !== sessionId) return false;
+    // Require sessionId to match when present; reject events without sessionId
+    // as a defensive measure against stale events from code paths that don't
+    // set it (sessionId is optional in the type for backward compatibility)
+    if (!sessionId || currentSession.id !== sessionId) return false;
     return true;
   };
 
@@ -481,12 +482,15 @@ export function setupInsightsListeners(): () => void {
 
   // Listen for status updates
   const unsubStatus = window.electronAPI.onInsightsStatus((projectId, status) => {
-    const currentSession = store().session;
-    if (!currentSession || currentSession.projectId !== projectId) return;
+    if (!isActiveSession(projectId, status.sessionId)) return;
     store().setStatus(status);
   });
 
   // Listen for errors
+  // Note: error events carry (projectId, errorString) without sessionId in the payload.
+  // projectId validation is sufficient here because cancelSession() kills the process
+  // on session switch, and the stream-chunk listener (the primary bleeding vector) has
+  // full sessionId validation.
   const unsubError = window.electronAPI.onInsightsError((projectId, error) => {
     const currentSession = store().session;
     if (!currentSession || currentSession.projectId !== projectId) return;

--- a/apps/frontend/src/renderer/stores/insights-store.ts
+++ b/apps/frontend/src/renderer/stores/insights-store.ts
@@ -402,9 +402,25 @@ export async function createTaskFromSuggestion(
 export function setupInsightsListeners(): () => void {
   const store = useInsightsStore.getState;
 
+  // Helper: check if an incoming event belongs to the currently active session.
+  // This prevents streaming responses from a previous chat from bleeding into
+  // the current chat when the user switches sessions mid-stream.
+  const isActiveSession = (projectId: string, sessionId?: string): boolean => {
+    const currentSession = store().session;
+    if (!currentSession) return false;
+    // Validate projectId matches
+    if (currentSession.projectId !== projectId) return false;
+    // If sessionId is provided in the chunk, validate it matches too
+    if (sessionId && currentSession.id !== sessionId) return false;
+    return true;
+  };
+
   // Listen for streaming chunks
   const unsubStreamChunk = window.electronAPI.onInsightsStreamChunk(
-    (_projectId, chunk: InsightsStreamChunk) => {
+    (projectId, chunk: InsightsStreamChunk) => {
+      // Drop events that don't belong to the currently active session
+      if (!isActiveSession(projectId, chunk.sessionId)) return;
+
       switch (chunk.type) {
         case 'text':
           if (chunk.content) {
@@ -464,12 +480,16 @@ export function setupInsightsListeners(): () => void {
   );
 
   // Listen for status updates
-  const unsubStatus = window.electronAPI.onInsightsStatus((_projectId, status) => {
+  const unsubStatus = window.electronAPI.onInsightsStatus((projectId, status) => {
+    const currentSession = store().session;
+    if (!currentSession || currentSession.projectId !== projectId) return;
     store().setStatus(status);
   });
 
   // Listen for errors
-  const unsubError = window.electronAPI.onInsightsError((_projectId, error) => {
+  const unsubError = window.electronAPI.onInsightsError((projectId, error) => {
+    const currentSession = store().session;
+    if (!currentSession || currentSession.projectId !== projectId) return;
     store().setStatus({
       phase: 'error',
       error

--- a/apps/frontend/src/shared/types/insights.ts
+++ b/apps/frontend/src/shared/types/insights.ts
@@ -223,6 +223,7 @@ export interface InsightsChatStatus {
 
 export interface InsightsStreamChunk {
   type: 'text' | 'task_suggestion' | 'tool_start' | 'tool_end' | 'done' | 'error';
+  sessionId?: string;
   content?: string;
   suggestedTasks?: Array<{
     title: string;

--- a/apps/frontend/src/shared/types/insights.ts
+++ b/apps/frontend/src/shared/types/insights.ts
@@ -217,6 +217,7 @@ export interface InsightsSessionSummary {
 
 export interface InsightsChatStatus {
   phase: 'idle' | 'thinking' | 'streaming' | 'complete' | 'error';
+  sessionId?: string;
   message?: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary

- **Bug:** When switching between conversations in the Insights tab while a response is still streaming, the LLM response from the previous chat bleeds into the new chat
- **Root cause:** Frontend streaming event listeners received a `projectId` parameter but completely ignored it (`_projectId` — unused), so all streaming events were applied to whichever chat was currently active regardless of origin
- **Additional issue:** `InsightsService.switchSession()` and `createNewSession()` did not cancel the active executor process, so the old Python process kept streaming even after the user switched away

## Changes

| File | Change |
|------|--------|
| `shared/types/insights.ts` | Added `sessionId` field to both `InsightsStreamChunk` and `InsightsChatStatus` for conversation-level event tracing |
| `main/insights/insights-executor.ts` | Accepts `sessionId` and includes it in all emitted stream chunks, status events, and error events |
| `main/insights-service.ts` | Passes `session.id` to executor; cancels active executor on `switchSession()` and `createNewSession()`; loads session early so pre-validation errors include `sessionId` |
| `main/ipc-handlers/insights-handlers.ts` | Forwards `sessionId` on error events to renderer; includes `sessionId` in IPC-level error paths ("Project not found", catch block) |
| `preload/api/modules/insights-api.ts` | Updated `onInsightsError` callback signature to include `sessionId` |
| `renderer/stores/insights-store.ts` | All three listeners (stream-chunk, status, error) consistently use `isActiveSession()` to validate both `projectId` and `sessionId` |

## How it fixes the bug

1. **Defense in depth at the frontend store** — An `isActiveSession()` guard drops any streaming chunk, status update, or error whose `projectId` or `sessionId` doesn't match the currently displayed session. Events without a `sessionId` are also rejected as a defensive measure against stale events from untagged code paths.
2. **Kill at the source** — `switchSession()` and `createNewSession()` now call `executor.cancelSession()` to terminate the old Python process, stopping stale events from being emitted at all.
3. **Session-level granularity** — `sessionId` is threaded through every event type (stream chunks, status, errors), so even within the same project, events from conversation A won't leak into conversation B.
4. **Pre-session errors preserved** — Early error paths (missing project, missing Auto Claude source) now include `sessionId` when available, so they aren't silently dropped by the frontend guard.

## Test plan

- [ ] Open the Insights tab, start a conversation, and send a message
- [ ] While the response is still streaming, switch to a different conversation (or create a new one)
- [ ] Verify the old response does NOT appear in the new conversation
- [ ] Verify the new conversation works normally and can send/receive messages
- [ ] Verify switching back to the first conversation shows its messages correctly (saved by the backend)
- [ ] Verify status indicators (thinking/streaming/complete) don't bleed across sessions
- [ ] Verify error states from a killed process don't appear in the newly active session
- [ ] Verify configuration errors (e.g., missing backend source) still display in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session-scoped streaming and status updates: real-time updates, suggestions, and errors now include session context so only the active session is affected.
  * Error reporting now includes session context to improve accuracy of notifications and link errors to the correct session.

* **Bug Fixes**
  * Switching or creating sessions reliably cancels previous streaming to prevent cross-session noise and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->