### PR TITLE
chore: refine .gitignore to track .claude/docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,7 @@ dev/
 _bmad
 _bmad-output
 
-.claude
+# Claude Code - local only (docs/ is tracked)
+.claude/settings.local.json
+.claude/worktrees/
+.claude/local/


### PR DESCRIPTION
## Summary
- Replaces broad `.claude` ignore with specific ignores
- `.claude/docs/decisions.md` and `.claude/docs/wisdom.md` will now be tracked
- Only `settings.local.json`, `worktrees/`, and `local/` remain ignored

## Test plan
- [x] Verify `.claude/docs/*.md` is no longer gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to refine version control exclusion patterns for local development artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->